### PR TITLE
Issue 4: strict cassette replay wrapper

### DIFF
--- a/docs/cassette-replay.md
+++ b/docs/cassette-replay.md
@@ -14,9 +14,11 @@ Status: draft design matching explicit owner request (Dec 2025). Each API call l
   },
   "request": {
     "model": "gemini-2.5-flash",
-    "systemPrompt": "SYSTEM ROLE: ...",
-    "materialsUsed": ["expert-model-of-x-risk"],
-    "history": [{ "...": "news events exactly as sent" }]
+    "contents": "[{\"type\":\"news-published\",...}]",
+    "config": {
+      "systemInstruction": "SYSTEM ROLE: ...",
+      "responseMimeType": "application/json"
+    }
   },
   "stream": [
     { "delayNs": 0,        "text": "[{\"type\":\"news-published\",...}]" },
@@ -27,10 +29,12 @@ Status: draft design matching explicit owner request (Dec 2025). Each API call l
 ```
 - `delayNs`: nanoseconds after the previous chunk before yielding this chunk (first chunk delay is since call start).
 - `text`: raw string as yielded by the SDK (`part.text` after calling the function if it was lazy).
-- `materialsUsed` is optional; history must be the news-only array actually sent.
+- `request` is the exact `generateContentStream` payload; contents must match byte-for-byte (whitespace included).
+- Only `meta.recordedAt` is ignored during request matching.
 
-## APIs (engine)
-- `createReplayForecaster({ tapePath, strict? })` — Forecaster that replays `stream` with delays, parsing chunks through the same streaming pipeline; validates model/systemPrompt/history when `strict` (default).
+## APIs (engine, Node-only)
+Import from `@ai-forecasting/engine/node` to avoid bundling node:fs into the webapp.
+- `createReplayForecaster({ tapePath, strict? })` — Forecaster that replays `stream` with delays, parsing chunks through the same streaming pipeline; validates the full request when `strict` (default).
 - `createReplayGenAIClient(tape)` — Mock GenAI client implementing `generateContentStream`, for use with lower-level helpers.
 - `createRecordingGenAIClient({ baseClient, tapePath, meta? })` — Wraps a real client, records chunk texts plus inter-chunk delays, writes one tape JSON to `tapePath`, passes through the original stream unchanged.
 - `loadReplayTape(path)` — Reads + validates tape JSON.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -7,6 +7,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./node": "./dist/node.js",
     "./adapters/*": "./dist/adapters/*.js",
     "./data": "./dist/data/index.js"
   },

--- a/packages/engine/src/forecaster/replayTypes.ts
+++ b/packages/engine/src/forecaster/replayTypes.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { NewsPublishedEvent } from '../types.js';
+import type { GenerateContentConfig } from '@google/genai';
 
 /**
  * Recorded Gemini streaming session for one request. Stored as JSON (not JSONL).
@@ -11,6 +11,12 @@ export interface ReplayChunk {
   text: string;
 }
 
+export interface ReplayRequest {
+  model: string;
+  contents: string;
+  config: GenerateContentConfig;
+}
+
 export interface ReplayTape {
   meta: {
     label?: string;
@@ -19,13 +25,7 @@ export interface ReplayTape {
     sdk?: string;
     comment?: string;
   };
-  request: {
-    model: string;
-    systemPrompt: string;
-    materialsUsed?: string[];
-    /** History sent to the model; should be news-only. */
-    history: NewsPublishedEvent[];
-  };
+  request: ReplayRequest;
   stream: ReplayChunk[];
 }
 
@@ -45,10 +45,8 @@ export const ReplayTapeSchema = z.object({
   }),
   request: z.object({
     model: z.string(),
-    systemPrompt: z.string(),
-    materialsUsed: z.array(z.string()).optional(),
-    history: z.any(), // validated downstream to avoid circular import
+    contents: z.string(),
+    config: z.any(),
   }),
   stream: z.array(ReplayChunkSchema),
 });
-

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -46,12 +46,6 @@ export {
 export { createBrowserForecaster } from './adapters/geminiBrowserForecaster.js';
 export { createNodeForecaster } from './adapters/geminiNodeForecaster.js';
 export { createMockForecaster } from './adapters/mockForecaster.js';
-export { createReplayForecaster } from './adapters/replayForecaster.js';
-export {
-  loadReplayTape,
-  createReplayGenAIClient,
-  createRecordingGenAIClient,
-} from './forecaster/replayClient.js';
 export type { ReplayTape, ReplayChunk } from './forecaster/replayTypes.js';
 import type { EngineConfig as Config, EngineApi, EngineEvent } from './types.js';
 import { coerceScenarioEvents, sortAndDedupEvents, nextDateAfter, assertChronology } from './utils/events.js';

--- a/packages/engine/src/node.ts
+++ b/packages/engine/src/node.ts
@@ -1,0 +1,7 @@
+export { createReplayForecaster } from './adapters/replayForecaster.js';
+export {
+  loadReplayTape,
+  createReplayGenAIClient,
+  createRecordingGenAIClient,
+} from './forecaster/replayClient.js';
+export type { ReplayTape, ReplayChunk, ReplayRequest } from './forecaster/replayTypes.js';

--- a/packages/engine/test/replay.test.ts
+++ b/packages/engine/test/replay.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createReplayForecaster } from '../src/adapters/replayForecaster.js';
+import { buildGenerateContentRequest } from '../src/forecaster/geminiStreaming.js';
 import { createEngine } from '../src/index.js';
 import { ICON_SET } from '../src/constants.js';
 
@@ -20,16 +21,17 @@ const baseHistory = [
 function writeTape(overrides: Partial<Record<'systemPrompt', string>> = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'replay-'));
   const path = join(dir, 'tape.json');
+  const request = buildGenerateContentRequest({
+    model: 'gemini-2.5-flash',
+    history: baseHistory,
+    systemPrompt: overrides.systemPrompt ?? 'PROMPT',
+  });
   const tape = {
     meta: {
       model: 'gemini-2.5-flash',
       recordedAt: '2025-12-10T00:00:00Z',
     },
-    request: {
-      model: 'gemini-2.5-flash',
-      systemPrompt: overrides.systemPrompt ?? 'PROMPT',
-      history: baseHistory,
-    },
+    request,
     stream: [
       {
         delayNs: 0,
@@ -64,6 +66,6 @@ describe('replay forecaster', () => {
     const tapePath = writeTape({ systemPrompt: 'PROMPT-A' });
     const forecaster = createReplayForecaster({ tapePath, strict: true });
     const engine = createEngine({ forecaster, systemPrompt: 'PROMPT-B' });
-    await expect(engine.forecast(baseHistory)).rejects.toThrow(/systemPrompt mismatch/);
+    await expect(engine.forecast(baseHistory)).rejects.toThrow(/request mismatch/i);
   });
 });


### PR DESCRIPTION
Closes #4\n\nWhat changed\n- record/replay tapes now store full generateContentStream request payload and strict-match it\n- refactored streaming request builder for reuse in replay strict checks + tests\n- moved replay/recording exports to a node-only entrypoint to keep browser bundles clean\n\nHow tested\n- npm test -w packages/engine