### PR TITLE
Issue 19: align CLI with Command[] contract

### DIFF
--- a/packages/cli/src/commands/aggregate.ts
+++ b/packages/cli/src/commands/aggregate.ts
@@ -1,6 +1,7 @@
-import { readFile, writeFile } from 'node:fs/promises';
-import { aggregate, coerceScenarioEvents } from '@ai-forecasting/engine';
-import type { ScenarioEvent } from '@ai-forecasting/engine';
+import { writeFile } from 'node:fs/promises';
+import { aggregate } from '@ai-forecasting/engine';
+import type { EngineEvent } from '@ai-forecasting/engine';
+import { readEngineEvents, writeEventsJsonl } from './eventIo.js';
 
 // One-shot aggregator: derives state from history (+optional new events).
 export async function runAggregate(opts: {
@@ -10,31 +11,20 @@ export async function runAggregate(opts: {
   outputState: string;
   outputHistory?: string;
 }) {
-  const history: ScenarioEvent[] = [];
+  const history: EngineEvent[] = [];
 
   if (opts.inputHistory) {
-    history.push(...(await readEvents(opts.inputHistory, 'input-history')));
+    history.push(...(await readEngineEvents(opts.inputHistory, 'input-history')));
   }
 
   if (opts.newEvents) {
-    history.push(...(await readEvents(opts.newEvents, 'new-events')));
+    history.push(...(await readEngineEvents(opts.newEvents, 'new-events')));
   }
 
   const state = aggregate(history);
   await writeFile(opts.outputState, JSON.stringify(state, null, 2));
 
   if (opts.outputHistory) {
-    await writeEvents(opts.outputHistory, history);
+    await writeEventsJsonl(opts.outputHistory, history);
   }
-}
-
-async function readEvents(path: string, label: string): Promise<ScenarioEvent[]> {
-  const text = await readFile(path, 'utf-8');
-  const lines = text.split(/\r?\n/).filter(Boolean).map(line => JSON.parse(line));
-  return coerceScenarioEvents(lines, label);
-}
-
-async function writeEvents(path: string, events: ScenarioEvent[]) {
-  const lines = events.map(evt => JSON.stringify(evt)).join('\n');
-  await writeFile(path, lines);
 }

--- a/packages/cli/src/commands/eventIo.ts
+++ b/packages/cli/src/commands/eventIo.ts
@@ -1,0 +1,59 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import {
+  EngineEventSchema,
+  ScenarioEventSchema,
+  sortAndDedupEvents,
+  type EngineEvent,
+} from '@ai-forecasting/engine';
+
+type Issue = { path: Array<string | number>; message: string };
+
+export async function readEngineEvents(path: string, label: string): Promise<EngineEvent[]> {
+  const text = await readFile(path, 'utf-8');
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  const events: EngineEvent[] = lines.map((line, index) => {
+    const lineNumber = index + 1;
+    let payload: unknown;
+    try {
+      payload = JSON.parse(line);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`${label}: invalid JSON on line ${lineNumber}: ${message}`);
+    }
+    return parseEvent(payload, label, lineNumber);
+  });
+  return sortAndDedupEvents(events);
+}
+
+export async function writeEventsJsonl(path: string, events: EngineEvent[]) {
+  const lines = events.map(evt => JSON.stringify(evt)).join('\n');
+  await writeFile(path, lines, 'utf-8');
+}
+
+export function formatZodIssues(issues: Issue[]): string {
+  if (!issues.length) return 'Unknown schema error.';
+  return issues
+    .map(issue => {
+      const loc = issue.path.length ? issue.path.join('.') : '(root)';
+      return `- ${loc}: ${issue.message}`;
+    })
+    .join('\n');
+}
+
+function parseEvent(payload: unknown, label: string, lineNumber: number): EngineEvent {
+  if (payload && typeof payload === 'object' && typeof (payload as { type?: unknown }).type === 'string') {
+    const raw = payload as Record<string, unknown>;
+    const normalized = raw.type === 'news' ? { ...raw, type: 'news-published' } : raw;
+    const result = EngineEventSchema.safeParse(normalized);
+    if (result.success) return result.data;
+    throw new Error(
+      `${label}: invalid engine event on line ${lineNumber}.\n${formatZodIssues(result.error.issues)}`
+    );
+  }
+
+  const scenario = ScenarioEventSchema.safeParse(payload);
+  if (scenario.success) return scenario.data as EngineEvent;
+  throw new Error(
+    `${label}: invalid scenario event on line ${lineNumber}.\n${formatZodIssues(scenario.error.issues)}`
+  );
+}

--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -1,20 +1,182 @@
-import { writeFile, readFile } from 'node:fs/promises';
-import { ScenarioEventArraySchema, type ScenarioEvent } from '@ai-forecasting/engine';
+import { readFile } from 'node:fs/promises';
+import {
+  CommandArraySchema,
+  EngineEventSchema,
+  type Command,
+  type EngineEvent,
+  normalizePublishNews,
+} from '@ai-forecasting/engine';
+import { formatZodIssues, writeEventsJsonl } from './eventIo.js';
 
-// Parses a raw Gemini response file into validated ScenarioEvents JSONL.
+// Parses a raw Gemini response file into validated EngineEvents JSONL.
 export async function runParse(opts: {
   inputJson: string;
   outputEvents: string;
 }) {
   const raw = await readFile(opts.inputJson, 'utf-8');
-  const parsed = JSON.parse(raw);
-  // Assume parsed.text contains JSON array; adjust if SDK shape differs.
-  const text = typeof parsed.text === 'string' ? parsed.text : JSON.stringify(parsed, null, 2);
-  const events = ScenarioEventArraySchema.parse(JSON.parse(text));
-  await writeJsonl(opts.outputEvents, events);
+  const { commands } = extractCommands(raw);
+  const events = commands.flatMap(commandToEvents);
+  const validated = EngineEventSchema.array().parse(events);
+  await writeEventsJsonl(opts.outputEvents, validated);
 }
 
-async function writeJsonl(path: string, events: ScenarioEvent[]) {
-  const lines = events.map(evt => JSON.stringify(evt)).join('\n');
-  await writeFile(path, lines, 'utf-8');
+function extractCommands(raw: string): { commands: Command[]; source: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error('parse: input file is empty.');
+  }
+
+  let parsed: unknown | null = null;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    parsed = null;
+  }
+
+  if (parsed !== null) {
+    const direct = CommandArraySchema.safeParse(parsed);
+    if (direct.success) {
+      return { commands: direct.data, source: 'direct-json' };
+    }
+  }
+
+  const text = parsed !== null ? extractText(parsed) : trimmed;
+  if (!text || !text.trim()) {
+    throw new Error('parse: no model text found in input JSON (expected response.text or chunks[].text).');
+  }
+
+  return parseCommandsFromText(text);
+}
+
+function parseCommandsFromText(text: string): { commands: Command[]; source: string } {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw new Error('parse: model text was empty after trimming.');
+  }
+
+  const parsed = tryParseJson(trimmed);
+  if (parsed.ok) {
+    return {
+      commands: parseCommandArray(parsed.value, 'model-text (JSON)'),
+      source: 'model-text-json',
+    };
+  }
+
+  const parsedJsonl = tryParseJsonl(trimmed);
+  if (parsedJsonl.ok) {
+    return {
+      commands: parseCommandArray(parsedJsonl.value, 'model-text (JSONL)'),
+      source: 'model-text-jsonl',
+    };
+  }
+
+  const snippet = summarize(trimmed);
+  throw new Error(
+    `parse: model text is not valid JSON/JSONL.\n- JSON error: ${parsed.error}\n- JSONL error: ${parsedJsonl.error}\n- Excerpt: ${snippet}`
+  );
+}
+
+function parseCommandArray(payload: unknown, label: string): Command[] {
+  const result = CommandArraySchema.safeParse(payload);
+  if (result.success) return result.data;
+  throw new Error(`parse: ${label} does not match Command[] schema.\n${formatZodIssues(result.error.issues)}`);
+}
+
+function commandToEvents(cmd: Command): EngineEvent[] {
+  switch (cmd.type) {
+    case 'publish-news':
+      return [normalizePublishNews(cmd)];
+    case 'open-story':
+      return [{ type: 'story-opened', id: cmd.refId, date: cmd.date }];
+    case 'close-story':
+      return [{ type: 'story-closed', id: cmd.refId, date: cmd.date }];
+    default:
+      return [];
+  }
+}
+
+function extractText(parsed: unknown): string | null {
+  if (typeof parsed === 'string') return parsed;
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const candidate = parsed as Record<string, unknown>;
+  const directText = readTextField(candidate);
+  if (directText) return directText;
+
+  if (Array.isArray(candidate.chunks)) {
+    const chunkText = candidate.chunks
+      .map(chunk => extractText(chunk))
+      .filter(Boolean)
+      .join('');
+    if (chunkText) return chunkText;
+  }
+
+  if (candidate.response) {
+    const responseText = extractText(candidate.response);
+    if (responseText) return responseText;
+  }
+
+  if (Array.isArray(candidate.candidates)) {
+    const partsText = extractTextFromCandidates(candidate.candidates);
+    if (partsText) return partsText;
+  }
+
+  if (candidate.content) {
+    const contentText = extractTextFromContent(candidate.content);
+    if (contentText) return contentText;
+  }
+
+  return null;
+}
+
+function extractTextFromCandidates(candidates: unknown[]): string | null {
+  const parts: string[] = [];
+  for (const candidate of candidates) {
+    const value = extractTextFromContent((candidate as { content?: unknown }).content);
+    if (value) parts.push(value);
+    const direct = readTextField(candidate as Record<string, unknown>);
+    if (direct) parts.push(direct);
+  }
+  return parts.length ? parts.join('') : null;
+}
+
+function extractTextFromContent(content: unknown): string | null {
+  if (!content || typeof content !== 'object') return null;
+  const parts = (content as { parts?: unknown }).parts;
+  if (!Array.isArray(parts)) return null;
+  const textParts = parts
+    .map(part => readTextField(part as Record<string, unknown>))
+    .filter(Boolean);
+  return textParts.length ? textParts.join('') : null;
+}
+
+function readTextField(value: Record<string, unknown> | null | undefined): string | null {
+  if (!value) return null;
+  const text = value.text;
+  return typeof text === 'string' ? text : null;
+}
+
+function tryParseJson(text: string): { ok: true; value: unknown } | { ok: false; error: string } {
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+function tryParseJsonl(text: string): { ok: true; value: unknown[] } | { ok: false; error: string } {
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  try {
+    return { ok: true, value: lines.map(line => JSON.parse(line)) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+function summarize(text: string, limit = 320) {
+  const singleLine = text.replace(/\s+/g, ' ').trim();
+  if (singleLine.length <= limit) return singleLine;
+  return `${singleLine.slice(0, limit)}…`;
 }

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -1,8 +1,38 @@
-import { readFile, writeFile } from 'node:fs/promises';
-import { coerceScenarioEvents, MATERIALS, preparePrompt, PreparedPromptSchema, type ScenarioEvent } from '@ai-forecasting/engine';
+import { writeFile } from 'node:fs/promises';
+import { MATERIALS, preparePrompt, PreparedPromptSchema } from '@ai-forecasting/engine';
+import { readEngineEvents } from './eventIo.js';
 
 // Builds a self-contained prompt.json (with inlined materials) for later call/replay.
 // OPEN QUESTION: owner to confirm contents shape (string vs Content[]); see PreparedPrompt comment in engine.
+const DEFAULT_SYSTEM_PROMPT = `SYSTEM ROLE: Simulation engine for an AI takeoff timeline.
+
+YOU RECEIVE:
+- A timeline history rendered as JSONL (one event per line).
+- A dynamic block with the latest known date and current turn window.
+- The user controls ONE organization. Default: the United States government and military.
+
+YOU OUTPUT:
+- Strictly a JSON array of Command objects (no extra text, no markdown).
+- Command schema:
+  - publish-news: { type: "publish-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string, postMortem?: boolean }
+  - open-story: { type: "open-story", refId: string, date: "YYYY-MM-DD" }
+  - close-story: { type: "close-story", refId: string, date: "YYYY-MM-DD" }
+- All command dates must be on or after the latest date in history.
+- For publish-news.icon, use a valid icon name from the Lucide icon library in PascalCase (e.g., "Landmark").
+- Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
+- Include postMortem: true only for events that should stay hidden until post-mortem review.
+- Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
+- Aim for 1–5 commands per turn to preserve alternation pacing.
+
+SCOPE AND STYLE:
+- Simulate a single concrete continuation that is detailed and specific.
+- Focus on AI labs, model releases, evals/safety, compute supply chain, corporate moves, regulation, geopolitics affecting AI, macroeconomy, and social/cultural shifts tied to AI.
+- Prefer quantitative magnitudes (orders of magnitude, percentages, dates) where suitable.
+- Avoid buzzwords and vague verbs. Be concise and factual.
+
+CHECKS BEFORE SENDING:
+- Output is valid JSON representing Command[].
+- Dates are non-decreasing.`;
 export async function runPrepare(opts: {
   inputState: string;
   inputHistory: string;
@@ -15,7 +45,7 @@ export async function runPrepare(opts: {
   const mats = selectMaterials(opts.materials);
   const prompt = preparePrompt({
     model: opts.model,
-    systemPrompt: opts.systemPrompt,
+    systemPrompt: opts.systemPrompt || DEFAULT_SYSTEM_PROMPT,
     history,
     materials: mats,
   });
@@ -31,8 +61,6 @@ function selectMaterials(spec?: string) {
   return MATERIALS.filter(m => ids.includes(m.id));
 }
 
-async function readEvents(path: string, label: string): Promise<ScenarioEvent[]> {
-  const text = await readFile(path, 'utf-8');
-  const lines = text.split(/\r?\n/).filter(Boolean).map(line => JSON.parse(line));
-  return coerceScenarioEvents(lines, label);
+async function readEvents(path: string, label: string) {
+  return readEngineEvents(path, label);
 }

--- a/packages/cli/test/parse.test.ts
+++ b/packages/cli/test/parse.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { runParse } from '../src/commands/parse.js';
+
+describe('runParse', () => {
+  it('parses Command[] from response.text into EngineEvent JSONL', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cli-parse-'));
+    const inputJson = join(dir, 'input.json');
+    const outputEvents = join(dir, 'output.jsonl');
+    const commands = [
+      {
+        type: 'publish-news',
+        date: '2025-01-02',
+        icon: 'Landmark',
+        title: 'Test headline',
+        description: 'Test description',
+      },
+      {
+        type: 'open-story',
+        refId: 'story-1',
+        date: '2025-01-02',
+      },
+    ];
+
+    await writeFile(inputJson, JSON.stringify({ response: { text: JSON.stringify(commands) } }), 'utf-8');
+    await runParse({ inputJson, outputEvents });
+
+    const lines = (await readFile(outputEvents, 'utf-8')).split(/\r?\n/).filter(Boolean);
+    const events = lines.map(line => JSON.parse(line));
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      type: 'news-published',
+      title: 'Test headline',
+    });
+    expect(events[1]).toMatchObject({
+      type: 'story-opened',
+      id: 'story-1',
+      date: '2025-01-02',
+    });
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -7,6 +7,7 @@ export {
   nextDateAfter,
   assertChronology,
 } from './utils/events.js';
+export { normalizePublishNews } from './utils/normalize.js';
 export type {
   ScenarioEvent,
   EngineEvent,


### PR DESCRIPTION
Closes #19

What changed
- align CLI prepare/parse around Command[] output
- add shared engine-event IO + validation in CLI
- add parse command test

How you tested
- npm run build -w packages/engine
- npm test -w packages/cli