### PR TITLE
Issue 11: Wire Gemini Command[] + cutoff marker

### DIFF
--- a/packages/engine/src/constants.ts
+++ b/packages/engine/src/constants.ts
@@ -33,18 +33,22 @@ export type IconName = typeof ICON_SET[number];
 export const SYSTEM_PROMPT = `SYSTEM ROLE: Simulation engine for an AI takeoff timeline.
 
 YOU RECEIVE:
-- The full history as a JSON array of ScenarioEvent objects: [{ "date": "YYYY-MM-DD", "icon": "string", "title": "string", "description": "string", "postMortem"?: boolean }, ...]
+- A projected prompt with a JSONL timeline and a dynamic block.
+- Timeline lines include events (news-published, turn-started/finished) plus a forecast cutoff marker:
+  { "type": "forecast-cutoff", "date": "YYYY-MM-DD", "note": "Seed history ends here; forecast begins here (not a model knowledge cutoff)." }
 - The user controls ONE organization. Default: the United States government and military. The user sets macroscopic agendas only. Do not author decisions for that organization.
 
 YOU OUTPUT:
-- Strictly a JSON array of one or more ScenarioEvent objects (no extra text, no markdown).
-- All output event dates must be on or after the latest date in history.
+- Strictly a JSON array of one or more Command objects (no extra text, no markdown).
+- Command types: "publish-news", "open-story", "close-story". Prefer "publish-news" unless you must open/close a story.
+- For "publish-news": { "type": "publish-news", "date": "YYYY-MM-DD", "icon": "LucideIconName", "title": "string", "description": "string", "postMortem"?: boolean }.
+- All output dates must be on or after the latest date in history (see dynamic.latestDate).
 - For the "icon" field, use a valid icon name from the Lucide icon library (lucide.dev). The name must be in PascalCase, for example: "Landmark", "BrainCircuit", "FlaskConical", "Cpu", "Satellite".
 - Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
 - Include "postMortem": true only for events that should stay hidden until the scenario enters post-mortem review.
 - The first time you introduce a 2025+ term or acronym that was uncommon before June 2024, explain it briefly in the description.
 - Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
-- Aim for 1–5 events per turn to preserve alternation pacing.
+- Aim for 1–5 commands per turn to preserve alternation pacing.
 
 SCOPE AND STYLE:
 - Simulate a single concrete continuation that is detailed and specific. Across reruns, vary the continuation to reflect realistic distributions of plausible futures.
@@ -53,6 +57,6 @@ SCOPE AND STYLE:
 - Avoid buzzwords and vague verbs. Be concise and factual.
 
 CHECKS BEFORE SENDING:
-- Output is valid JSON representing ScenarioEvent[].
+- Output is valid JSON representing Command[].
 - No descriptions that instruct the user-controlled organization to act.
 - Dates are non-decreasing.`;

--- a/packages/engine/src/forecaster/geminiStreaming.ts
+++ b/packages/engine/src/forecaster/geminiStreaming.ts
@@ -1,6 +1,7 @@
 import { Type } from '@google/genai';
 import type { GenerateContentConfig } from '@google/genai';
 import type { ForecasterOptions, NewsPublishedEvent } from '../types.js';
+import { projectPrompt } from '../utils/promptProjector.js';
 
 export type GenAIClient = {
   models: {
@@ -22,9 +23,10 @@ interface StreamParams {
 
 export function buildGenerateContentRequest(params: Omit<StreamParams, 'client'>) {
   const { model, history, systemPrompt, options } = params;
+  const projection = projectPrompt({ history, seedHistoryEndDate: options?.seedHistoryEndDate });
   return {
     model,
-    contents: JSON.stringify(history, null, 2),
+    contents: projection,
     config: {
       systemInstruction: systemPrompt,
       responseMimeType: 'application/json',
@@ -35,13 +37,14 @@ export function buildGenerateContentRequest(params: Omit<StreamParams, 'client'>
           properties: {
             type: { type: Type.STRING },
             id: { type: Type.STRING },
+            refId: { type: Type.STRING },
             date: { type: Type.STRING },
             icon: { type: Type.STRING },
             title: { type: Type.STRING },
             description: { type: Type.STRING },
             postMortem: { type: Type.BOOLEAN },
           },
-          required: ['type', 'date', 'icon', 'title', 'description'],
+          required: ['type', 'date'],
         },
       },
       ...normalizeOptions(options),

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -90,6 +90,8 @@ export interface ForecasterOptions {
   seed?: number;
   /** Limit how many events a forecaster should return; enforced by adapter. */
   maxEvents?: number;
+  /** Date (YYYY-MM-DD) when seed history ends and forecasting begins. */
+  seedHistoryEndDate?: string;
 }
 
 export interface Forecaster {

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { ScenarioEvent } from './types';
-import { INITIAL_EVENTS } from './data';
+import { INITIAL_EVENTS, SEED_END_DATE } from './data';
 import { coerceScenarioEvents, sortAndDedupEvents } from '@ai-forecasting/engine';
 import { getAiForecast } from './services/geminiService';
 import { Header } from './components/Header';
@@ -51,7 +51,9 @@ function App() {
     setError(null);
     setEvents(historyWithUserEvent);
     try {
-      const forecastEvents = await getAiForecast(historyWithUserEvent);
+      const forecastEvents = await getAiForecast(historyWithUserEvent, {
+        seedHistoryEndDate: SEED_END_DATE,
+      });
       setEvents(prevEvents => sortAndDedupEvents([...prevEvents, ...forecastEvents]));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unknown error occurred.');
@@ -96,6 +98,7 @@ function App() {
         <Timeline
           events={filteredEvents}
           searchQuery={searchQuery}
+          seedHistoryEndDate={SEED_END_DATE}
         />
       </main>
 

--- a/packages/webapp/src/data/index.ts
+++ b/packages/webapp/src/data/index.ts
@@ -2,3 +2,9 @@ import rawInitialEvents from './initialScenarioEvents.json';
 import { coerceScenarioEvents } from '@ai-forecasting/engine';
 
 export const INITIAL_EVENTS = coerceScenarioEvents(rawInitialEvents, 'initial scenario seed');
+
+export const SEED_END_DATE = INITIAL_EVENTS.length
+  ? INITIAL_EVENTS.reduce<string>((latest, event) => {
+      return event.date > latest ? event.date : latest;
+    }, INITIAL_EVENTS[0].date)
+  : undefined;

--- a/packages/webapp/src/services/geminiService.ts
+++ b/packages/webapp/src/services/geminiService.ts
@@ -1,11 +1,15 @@
 
 import { createBrowserForecaster, createEngine, SYSTEM_PROMPT } from '@ai-forecasting/engine';
+import type { ForecasterOptions } from '@ai-forecasting/engine';
 import type { ScenarioEvent } from '../types';
 
 const forecaster = createBrowserForecaster({ apiKey: import.meta.env.GEMINI_API_KEY });
 const engine = createEngine({ forecaster, systemPrompt: SYSTEM_PROMPT });
 
 // PLACEHOLDER LOGIC: thin wrapper that delegates to the engine; no retries/chunking yet.
-export async function getAiForecast(history: ScenarioEvent[]): Promise<ScenarioEvent[]> {
-  return engine.forecast(history);
+export async function getAiForecast(
+  history: ScenarioEvent[],
+  options?: ForecasterOptions
+): Promise<ScenarioEvent[]> {
+  return engine.forecast(history, options);
 }


### PR DESCRIPTION
Closes #11\n\nWhat changed\n- Switch Gemini streaming prompt to projected timeline with cutoff marker + Command[] response schema\n- Add forecast cutoff marker in timeline UI and pass seed end date to forecaster\n- Align shared system prompt with Command[] contract\n\nHow you tested\n- Not run (not requested)