### PR TITLE
Implement Contract v2 command/event model

### DIFF
--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -5,6 +5,7 @@ import {
   type Command,
   type EngineEvent,
   normalizePublishNews,
+  normalizePublishHiddenNews,
 } from '@ai-forecasting/engine';
 import { formatZodIssues, writeEventsJsonl } from './eventIo.js';
 
@@ -86,10 +87,12 @@ function commandToEvents(cmd: Command): EngineEvent[] {
   switch (cmd.type) {
     case 'publish-news':
       return [normalizePublishNews(cmd)];
-    case 'open-story':
-      return [{ type: 'story-opened', id: cmd.refId, date: cmd.date }];
-    case 'close-story':
-      return [{ type: 'story-closed', id: cmd.refId, date: cmd.date }];
+    case 'publish-hidden-news':
+      return [normalizePublishHiddenNews(cmd)];
+    case 'patch-news':
+      return [{ type: 'news-patched', id: cmd.id, date: cmd.date, patch: cmd.patch }];
+    case 'game-over':
+      return [{ type: 'game-over', date: cmd.date, summary: cmd.summary }];
     default:
       return [];
   }

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -14,13 +14,14 @@ YOU RECEIVE:
 YOU OUTPUT:
 - Strictly a JSON array of Command objects (no extra text, no markdown).
 - Command schema:
-  - publish-news: { type: "publish-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string, postMortem?: boolean }
-  - open-story: { type: "open-story", refId: string, date: "YYYY-MM-DD" }
-  - close-story: { type: "close-story", refId: string, date: "YYYY-MM-DD" }
+  - publish-news: { type: "publish-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
+  - publish-hidden-news: { type: "publish-hidden-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
+  - patch-news: { type: "patch-news", id: "existing-news-id", date: "YYYY-MM-DD", patch: { date?: "YYYY-MM-DD", icon?: IconName, title?: string, description?: string } }
+  - game-over: { type: "game-over", date: "YYYY-MM-DD", summary: string }
 - All command dates must be on or after the latest date in history.
 - For publish-news.icon, use a valid icon name from the Lucide icon library in PascalCase (e.g., "Landmark").
 - Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
-- Include postMortem: true only for events that should stay hidden until post-mortem review.
+- Use publish-hidden-news only for events that should be hidden from the player timeline.
 - Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
 - Aim for 1–5 commands per turn to preserve alternation pacing.
 

--- a/packages/cli/test/parse.test.ts
+++ b/packages/cli/test/parse.test.ts
@@ -13,15 +13,19 @@ describe('runParse', () => {
     const commands = [
       {
         type: 'publish-news',
+        id: 'news-1',
         date: '2025-01-02',
         icon: 'Landmark',
         title: 'Test headline',
         description: 'Test description',
       },
       {
-        type: 'open-story',
-        refId: 'story-1',
-        date: '2025-01-02',
+        type: 'patch-news',
+        id: 'news-1',
+        date: '2025-01-03',
+        patch: {
+          title: 'Updated headline',
+        },
       },
     ];
 
@@ -37,9 +41,9 @@ describe('runParse', () => {
       title: 'Test headline',
     });
     expect(events[1]).toMatchObject({
-      type: 'story-opened',
-      id: 'story-1',
-      date: '2025-01-02',
+      type: 'news-patched',
+      id: 'news-1',
+      date: '2025-01-03',
     });
   });
 });

--- a/packages/engine/src/adapters/geminiBrowserForecaster.ts
+++ b/packages/engine/src/adapters/geminiBrowserForecaster.ts
@@ -1,8 +1,8 @@
 import { GoogleGenAI } from '@google/genai';
-import type { Forecaster, ForecasterContext, ForecasterOptions, ScenarioEvent } from '../types.js';
+import type { Forecaster, ForecasterContext, ForecasterOptions, EngineEvent } from '../types.js';
 import { streamGeminiRaw, type GenAIClient } from '../forecaster/geminiStreaming.js';
 import { parseActionChunk } from '../forecaster/streamingPipeline.js';
-import { isNewsPublishedEvent } from '../utils/events.js';
+import { sortAndDedupEvents } from '../utils/events.js';
 
 interface BrowserForecasterConfig {
   apiKey: string | undefined;
@@ -26,14 +26,12 @@ export function createBrowserForecaster(config: BrowserForecasterConfig): Foreca
         throw new Error('GEMINI_API_KEY is missing. Add it to your .env.local or hosting env.');
       }
 
-      // Only send news events to the model; UI events like story-opened are omitted.
-      let history = context.history.filter(isNewsPublishedEvent) as ScenarioEvent[];
-      const events: ScenarioEvent[] = [];
+      let history = sortAndDedupEvents(context.history);
+      const events: EngineEvent[] = [];
       for await (const raw of streamGeminiRaw({ client: ai as unknown as GenAIClient, model, history, systemPrompt: context.systemPrompt, options })) {
         const { events: batch, nextHistory } = parseActionChunk({ actionsJsonl: raw }, history);
-        const newsOnly = batch.filter(isNewsPublishedEvent) as ScenarioEvent[];
-        events.push(...newsOnly);
-        history = nextHistory.filter(isNewsPublishedEvent) as ScenarioEvent[];
+        events.push(...batch);
+        history = sortAndDedupEvents(nextHistory);
       }
       return events;
     },

--- a/packages/engine/src/adapters/geminiNodeForecaster.ts
+++ b/packages/engine/src/adapters/geminiNodeForecaster.ts
@@ -1,8 +1,8 @@
 import { GoogleGenAI } from '@google/genai';
-import type { Forecaster, ForecasterContext, ForecasterOptions, ScenarioEvent } from '../types.js';
+import type { Forecaster, ForecasterContext, ForecasterOptions, EngineEvent } from '../types.js';
 import { streamGeminiRaw, type GenAIClient } from '../forecaster/geminiStreaming.js';
 import { parseActionChunk } from '../forecaster/streamingPipeline.js';
-import { isNewsPublishedEvent } from '../utils/events.js';
+import { sortAndDedupEvents } from '../utils/events.js';
 
 interface NodeForecasterConfig {
   apiKey?: string;
@@ -26,14 +26,12 @@ export function createNodeForecaster(config: NodeForecasterConfig = {}): Forecas
         throw new Error('GEMINI_API_KEY is missing. Export it before running the CLI.');
       }
 
-      // Only send news events to the model; UI events like story-opened are omitted.
-      let history = context.history.filter(isNewsPublishedEvent) as ScenarioEvent[];
-      const events: ScenarioEvent[] = [];
+      let history = sortAndDedupEvents(context.history);
+      const events: EngineEvent[] = [];
       for await (const raw of streamGeminiRaw({ client: ai as unknown as GenAIClient, model, history, systemPrompt: context.systemPrompt, options })) {
         const { events: batch, nextHistory } = parseActionChunk({ actionsJsonl: raw }, history);
-        const newsOnly = batch.filter(isNewsPublishedEvent) as ScenarioEvent[];
-        events.push(...newsOnly);
-        history = nextHistory.filter(isNewsPublishedEvent) as ScenarioEvent[];
+        events.push(...batch);
+        history = sortAndDedupEvents(nextHistory);
       }
       return events;
     },

--- a/packages/engine/src/adapters/mockForecaster.ts
+++ b/packages/engine/src/adapters/mockForecaster.ts
@@ -1,4 +1,4 @@
-import type { Forecaster, ForecasterContext, ScenarioEvent } from '../types.js';
+import type { Forecaster, ForecasterContext, EngineEvent } from '../types.js';
 import { nextDateAfter } from '../utils/events.js';
 
 export interface MockForecasterOptions {
@@ -11,7 +11,7 @@ export function createMockForecaster(opts: MockForecasterOptions = {}): Forecast
 
   return {
     name: 'mock',
-    async forecast(context: ForecasterContext): Promise<ScenarioEvent[]> {
+    async forecast(context: ForecasterContext): Promise<EngineEvent[]> {
       const nextDate = nextDateAfter(context.history);
       // PLACEHOLDER LOGIC: deterministic single event to keep flows testable without real AI.
       return [
@@ -22,7 +22,6 @@ export function createMockForecaster(opts: MockForecasterOptions = {}): Forecast
           icon: 'BrainCircuit',
           title: `${label} forecast event`,
           description: 'Placeholder forecast — replace with real model output when running with Gemini.',
-          postMortem: false,
         },
       ];
     },

--- a/packages/engine/src/adapters/replayForecaster.ts
+++ b/packages/engine/src/adapters/replayForecaster.ts
@@ -1,7 +1,7 @@
 import { parseActionChunk } from '../forecaster/streamingPipeline.js';
 import { buildGenerateContentRequest } from '../forecaster/geminiStreaming.js';
-import type { Forecaster, ForecasterContext, ForecasterOptions, ScenarioEvent } from '../types.js';
-import { isScenarioEvent, coerceScenarioEvents, sortAndDedupEvents } from '../utils/events.js';
+import type { Forecaster, ForecasterContext, ForecasterOptions, EngineEvent } from '../types.js';
+import { coerceEngineEvents, sortAndDedupEvents } from '../utils/events.js';
 import { loadReplayTape } from '../forecaster/replayClient.js';
 
 interface ReplayForecasterConfig {
@@ -19,11 +19,11 @@ export function createReplayForecaster(config: ReplayForecasterConfig): Forecast
 
   return {
     name: 'replay',
-    async forecast(context: ForecasterContext, options?: ForecasterOptions): Promise<ScenarioEvent[]> {
+    async forecast(context: ForecasterContext, options?: ForecasterOptions): Promise<EngineEvent[]> {
       const tape = await loadReplayTape(tapePath);
 
       if (strict) {
-        const incomingHistory = context.history.filter(isScenarioEvent);
+        const incomingHistory = sortAndDedupEvents(context.history);
         const request = buildGenerateContentRequest({
           model: tape.request.model,
           history: incomingHistory,
@@ -35,17 +35,16 @@ export function createReplayForecaster(config: ReplayForecasterConfig): Forecast
         }
       }
 
-      let history = normalizeHistory(context.history.filter(isScenarioEvent));
-      const events: ScenarioEvent[] = [];
+      let history = normalizeHistory(context.history);
+      const events: EngineEvent[] = [];
 
       for (const chunk of tape.stream) {
         if (chunk.delayNs && chunk.delayNs > 0) {
           await delayNs(chunk.delayNs);
         }
         const { events: batch, nextHistory } = parseActionChunk({ actionsJsonl: chunk.text }, history);
-        const newsOnly = batch.filter(isScenarioEvent) as ScenarioEvent[];
-        events.push(...newsOnly);
-        history = sortAndDedupEvents(nextHistory).filter(isScenarioEvent);
+        events.push(...batch);
+        history = sortAndDedupEvents(nextHistory);
       }
 
       return events;
@@ -53,9 +52,9 @@ export function createReplayForecaster(config: ReplayForecasterConfig): Forecast
   };
 }
 
-function normalizeHistory(events: unknown[]): ScenarioEvent[] {
-  const newsOnly = Array.isArray(events) ? events.filter(isScenarioEvent) : [];
-  const coerced = coerceScenarioEvents(newsOnly, 'replay-forecaster');
+function normalizeHistory(events: unknown[]): EngineEvent[] {
+  const payload = Array.isArray(events) ? events : [];
+  const coerced = coerceEngineEvents(payload, 'replay-forecaster');
   return sortAndDedupEvents(coerced);
 }
 

--- a/packages/engine/src/constants.ts
+++ b/packages/engine/src/constants.ts
@@ -34,18 +34,21 @@ export const SYSTEM_PROMPT = `SYSTEM ROLE: Simulation engine for an AI takeoff t
 
 YOU RECEIVE:
 - A projected prompt with a JSONL timeline and a dynamic block.
-- Timeline lines include events (news-published, turn-started/finished) plus a forecast cutoff marker:
+- Timeline lines include events (news-published, hidden-news-published, news-patched, turn-started/finished, scenario-head-completed) plus a forecast cutoff marker:
   { "type": "forecast-cutoff", "date": "YYYY-MM-DD", "note": "Seed history ends here; forecast begins here (not a model knowledge cutoff)." }
 - The user controls ONE organization. Default: the United States government and military. The user sets macroscopic agendas only. Do not author decisions for that organization.
 
 YOU OUTPUT:
 - Strictly a JSON array of one or more Command objects (no extra text, no markdown).
-- Command types: "publish-news", "open-story", "close-story". Prefer "publish-news" unless you must open/close a story.
-- For "publish-news": { "type": "publish-news", "date": "YYYY-MM-DD", "icon": "LucideIconName", "title": "string", "description": "string", "postMortem"?: boolean }.
+- Command types: "publish-news", "publish-hidden-news", "patch-news", "game-over".
+- For "publish-news": { "type": "publish-news", "date": "YYYY-MM-DD", "icon": "LucideIconName", "title": "string", "description": "string" }.
+- For "publish-hidden-news": { "type": "publish-hidden-news", "date": "YYYY-MM-DD", "icon": "LucideIconName", "title": "string", "description": "string" }.
+- For "patch-news": { "type": "patch-news", "id": "existing-news-id", "date": "YYYY-MM-DD", "patch": { "date"?: "YYYY-MM-DD", "icon"?: "LucideIconName", "title"?: "string", "description"?: "string" } }.
+- For "game-over": { "type": "game-over", "date": "YYYY-MM-DD", "summary": "string" }.
 - All output dates must be on or after the latest date in history (see dynamic.latestDate).
+- Use "publish-hidden-news" only for events that should be hidden from the player timeline.
 - For the "icon" field, use a valid icon name from the Lucide icon library (lucide.dev). The name must be in PascalCase, for example: "Landmark", "BrainCircuit", "FlaskConical", "Cpu", "Satellite".
 - Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
-- Include "postMortem": true only for events that should stay hidden until the scenario enters post-mortem review.
 - The first time you introduce a 2025+ term or acronym that was uncommon before June 2024, explain it briefly in the description.
 - Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
 - Aim for 1–5 commands per turn to preserve alternation pacing.

--- a/packages/engine/src/data/index.ts
+++ b/packages/engine/src/data/index.ts
@@ -1,4 +1,4 @@
 import rawInitialEvents from './initialScenarioEvents.json' assert { type: 'json' };
-import { coerceScenarioEvents } from '../utils/events.js';
+import { coerceEngineEvents } from '../utils/events.js';
 
-export const INITIAL_EVENTS = coerceScenarioEvents(rawInitialEvents, 'initial scenario seed');
+export const INITIAL_EVENTS = coerceEngineEvents(rawInitialEvents, 'initial scenario seed');

--- a/packages/engine/src/data/initialScenarioEvents.json
+++ b/packages/engine/src/data/initialScenarioEvents.json
@@ -226,5 +226,9 @@
     "icon": "Power",
     "title": "EU agrees to phase out Russian gas and oil by 2028; Russian gas share ~12–13% in 2025",
     "description": "EU energy ministers back a regulation to end Russian fossil imports by Jan 1, 2028 (subject to Parliament). Despite progress, Russian gas (including LNG) remains ~12–13% of EU imports in 2025, with variation by member state."
+  },
+  {
+    "type": "scenario-head-completed",
+    "date": "2025-10-30"
   }
 ]

--- a/packages/engine/src/forecaster/geminiStreaming.ts
+++ b/packages/engine/src/forecaster/geminiStreaming.ts
@@ -1,6 +1,6 @@
 import { Type } from '@google/genai';
 import type { GenerateContentConfig } from '@google/genai';
-import type { ForecasterOptions, NewsPublishedEvent } from '../types.js';
+import type { EngineEvent, ForecasterOptions } from '../types.js';
 import { projectPrompt } from '../utils/promptProjector.js';
 
 export type GenAIClient = {
@@ -16,14 +16,14 @@ export type GenAIClient = {
 interface StreamParams {
   client: GenAIClient;
   model: string;
-  history: NewsPublishedEvent[];
+  history: EngineEvent[];
   systemPrompt: string;
   options?: ForecasterOptions;
 }
 
 export function buildGenerateContentRequest(params: Omit<StreamParams, 'client'>) {
   const { model, history, systemPrompt, options } = params;
-  const projection = projectPrompt({ history, seedHistoryEndDate: options?.seedHistoryEndDate });
+  const projection = projectPrompt({ history });
   return {
     model,
     contents: projection,
@@ -33,18 +33,59 @@ export function buildGenerateContentRequest(params: Omit<StreamParams, 'client'>
       responseSchema: {
         type: Type.ARRAY,
         items: {
-          type: Type.OBJECT,
-          properties: {
-            type: { type: Type.STRING },
-            id: { type: Type.STRING },
-            refId: { type: Type.STRING },
-            date: { type: Type.STRING },
-            icon: { type: Type.STRING },
-            title: { type: Type.STRING },
-            description: { type: Type.STRING },
-            postMortem: { type: Type.BOOLEAN },
-          },
-          required: ['type', 'date'],
+          anyOf: [
+            {
+              type: Type.OBJECT,
+              properties: {
+                type: { type: Type.STRING, enum: ['publish-news'] },
+                id: { type: Type.STRING },
+                date: { type: Type.STRING },
+                icon: { type: Type.STRING },
+                title: { type: Type.STRING },
+                description: { type: Type.STRING },
+              },
+              required: ['type', 'date', 'icon', 'title', 'description'],
+            },
+            {
+              type: Type.OBJECT,
+              properties: {
+                type: { type: Type.STRING, enum: ['publish-hidden-news'] },
+                id: { type: Type.STRING },
+                date: { type: Type.STRING },
+                icon: { type: Type.STRING },
+                title: { type: Type.STRING },
+                description: { type: Type.STRING },
+              },
+              required: ['type', 'date', 'icon', 'title', 'description'],
+            },
+            {
+              type: Type.OBJECT,
+              properties: {
+                type: { type: Type.STRING, enum: ['patch-news'] },
+                id: { type: Type.STRING },
+                date: { type: Type.STRING },
+                patch: {
+                  type: Type.OBJECT,
+                  properties: {
+                    date: { type: Type.STRING },
+                    icon: { type: Type.STRING },
+                    title: { type: Type.STRING },
+                    description: { type: Type.STRING },
+                  },
+                },
+              },
+              required: ['type', 'id', 'date', 'patch'],
+            },
+            {
+              type: Type.OBJECT,
+              properties: {
+                type: { type: Type.STRING, enum: ['game-over'] },
+                date: { type: Type.STRING },
+                summary: { type: Type.STRING },
+              },
+              required: ['type', 'date', 'summary'],
+            },
+          ],
         },
       },
       ...normalizeOptions(options),

--- a/packages/engine/src/forecaster/streamingPipeline.ts
+++ b/packages/engine/src/forecaster/streamingPipeline.ts
@@ -1,6 +1,6 @@
 import { CommandArraySchema } from '../schemas.js';
-import type { Command, EngineEvent, PublishNewsCommand } from '../types.js';
-import { normalizePublishNews } from '../utils/normalize.js';
+import type { Command, EngineEvent, PatchNewsCommand, PublishHiddenNewsCommand, PublishNewsCommand } from '../types.js';
+import { normalizePublishHiddenNews, normalizePublishNews } from '../utils/normalize.js';
 
 export interface ActionBatch {
   actionsJsonl: string; // raw JSONL text chunk containing 1..n actions
@@ -14,13 +14,13 @@ export interface ParseResult {
 
 /**
  * Streaming parser (HELLO-WORLD PLACEHOLDER):
- * - Expects JSON/JSONL of Commands; 1 publish-news command ≙ 1 NewsPublished event.
+ * - Expects JSON/JSONL of Commands; publish-news/publish-hidden-news create news events.
  * - Validates each chunk with zod; no recovery or per-event state feedback yet.
  * - Emits once per chunk; nextState mirrors history until richer aggregates exist.
  *
  * EVENT SOURCING SKETCH (v0.1 target)
  *   prompt(history) -> Gemini stream -> parse/validate -> events -> history -> aggregates
- *   - LLM outputs engine events directly (NewsEvent today; later also NewsStoryOpenedEvent).
+ *   - LLM outputs engine events directly (News + patch + game-over).
  *   - Each validated event appends to history and updates aggregates; the next streamed
  *     item should validate against the fresh aggregates (not implemented yet).
  *   - UI state is ephemeral (React-only); reducible from history + defaults; may also
@@ -56,11 +56,29 @@ function commandToEvents(cmd: Command): EngineEvent[] {
     const news = normalizePublishNews(cmd as PublishNewsCommand);
     return [news];
   }
-  if (cmd.type === 'open-story') {
-    return [{ type: 'story-opened', id: cmd.refId, date: cmd.date }];
+  if (cmd.type === 'publish-hidden-news') {
+    const news = normalizePublishHiddenNews(cmd as PublishHiddenNewsCommand);
+    return [news];
   }
-  if (cmd.type === 'close-story') {
-    return [{ type: 'story-closed', id: cmd.refId, date: cmd.date }];
+  if (cmd.type === 'patch-news') {
+    const patch = cmd as PatchNewsCommand;
+    return [
+      {
+        type: 'news-patched',
+        id: patch.id,
+        date: patch.date,
+        patch: patch.patch,
+      },
+    ];
+  }
+  if (cmd.type === 'game-over') {
+    return [
+      {
+        type: 'game-over',
+        date: cmd.date,
+        summary: cmd.summary,
+      },
+    ];
   }
   return [];
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,22 +3,27 @@ export { INITIAL_EVENTS } from './data/index.js';
 export { MATERIALS, type MaterialDoc } from './data/materials.js';
 export {
   coerceScenarioEvents,
+  coerceEngineEvents,
   sortAndDedupEvents,
   nextDateAfter,
   assertChronology,
 } from './utils/events.js';
-export { normalizePublishNews } from './utils/normalize.js';
+export { normalizePublishNews, normalizePublishHiddenNews } from './utils/normalize.js';
 export { stripHtmlComments, stripCommentsFromMaterials } from './utils/materials.js';
 export type {
   ScenarioEvent,
   EngineEvent,
   Command,
   PublishNewsCommand,
-  OpenStoryCommand,
-  CloseStoryCommand,
+  PublishHiddenNewsCommand,
+  PatchNewsCommand,
+  GameOverCommand,
   NewsPublishedEvent,
-  StoryOpenedEvent,
-  StoryClosedEvent,
+  HiddenNewsPublishedEvent,
+  NewsPatchedEvent,
+  GameOverEvent,
+  ScenarioHeadCompletedEvent,
+  NewsEvent,
   TurnStartedEvent,
   TurnFinishedEvent,
   Forecaster,
@@ -31,13 +36,16 @@ export type {
 } from './types.js';
 export {
   PublishNewsCommandSchema,
-  OpenStoryCommandSchema,
-  CloseStoryCommandSchema,
+  PublishHiddenNewsCommandSchema,
+  PatchNewsCommandSchema,
+  GameOverCommandSchema,
   CommandSchema,
   CommandArraySchema,
   NewsPublishedEventSchema,
-  StoryOpenedEventSchema,
-  StoryClosedEventSchema,
+  HiddenNewsPublishedEventSchema,
+  NewsPatchedEventSchema,
+  GameOverEventSchema,
+  ScenarioHeadCompletedEventSchema,
   TurnStartedEventSchema,
   TurnFinishedEventSchema,
   EngineEventSchema,
@@ -50,7 +58,7 @@ export { createNodeForecaster } from './adapters/geminiNodeForecaster.js';
 export { createMockForecaster } from './adapters/mockForecaster.js';
 export type { ReplayTape, ReplayChunk } from './forecaster/replayTypes.js';
 import type { EngineConfig as Config, EngineApi, EngineEvent } from './types.js';
-import { coerceScenarioEvents, sortAndDedupEvents, nextDateAfter, assertChronology } from './utils/events.js';
+import { coerceEngineEvents, sortAndDedupEvents, nextDateAfter, assertChronology } from './utils/events.js';
 import type { AggregatedState, PreparedPrompt } from './types.js';
 import type { GenerateContentConfig, Content } from '@google/genai';
 import { projectPrompt } from './utils/promptProjector.js';
@@ -67,7 +75,7 @@ export function createEngine(config: Config): EngineApi {
   return {
     async forecast(history, options) {
       const forecastEvents = await forecaster.forecast({ history, systemPrompt: systemPrompt ?? '' }, options);
-      const validated = coerceScenarioEvents(forecastEvents, forecaster.name);
+      const validated = coerceEngineEvents(forecastEvents, forecaster.name);
       assertChronology(history, validated);
       return validated;
     },
@@ -77,7 +85,7 @@ export function createEngine(config: Config): EngineApi {
     nextDate(history) {
       return nextDateAfter(history);
     },
-    coerce: coerceScenarioEvents,
+    coerce: coerceEngineEvents,
   } satisfies EngineApi;
 }
 

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -20,25 +20,47 @@ export const PublishNewsCommandSchema = z.object({
   icon: z.enum(ICON_VALUES),
   title: z.string().min(1),
   description: z.string().min(1),
-  postMortem: z.boolean().optional(),
 });
 
-export const OpenStoryCommandSchema = z.object({
-  type: z.literal('open-story'),
-  refId: z.string().min(1),
+export const PublishHiddenNewsCommandSchema = z.object({
+  type: z.literal('publish-hidden-news'),
+  id: z.string().optional(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  icon: z.enum(ICON_VALUES),
+  title: z.string().min(1),
+  description: z.string().min(1),
 });
 
-export const CloseStoryCommandSchema = z.object({
-  type: z.literal('close-story'),
-  refId: z.string().min(1),
+const NewsPatchSchema = z
+  .object({
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    icon: z.enum(ICON_VALUES).optional(),
+    title: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+  })
+  .refine(
+    patch => !!patch.date || !!patch.icon || !!patch.title || !!patch.description,
+    'patch-news requires at least one field to update.'
+  );
+
+export const PatchNewsCommandSchema = z.object({
+  type: z.literal('patch-news'),
+  id: z.string().min(1),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  patch: NewsPatchSchema,
+});
+
+export const GameOverCommandSchema = z.object({
+  type: z.literal('game-over'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  summary: z.string().min(1),
 });
 
 export const CommandSchema = z.discriminatedUnion('type', [
   PublishNewsCommandSchema,
-  OpenStoryCommandSchema,
-  CloseStoryCommandSchema,
+  PublishHiddenNewsCommandSchema,
+  PatchNewsCommandSchema,
+  GameOverCommandSchema,
 ]);
 
 export const CommandArraySchema = z.array(CommandSchema);
@@ -51,19 +73,22 @@ export const NewsPublishedEventSchema = z.object({
   icon: z.enum(ICON_VALUES),
   title: z.string().min(1),
   description: z.string().min(1),
-  postMortem: z.boolean().optional(),
 });
 
-export const StoryOpenedEventSchema = z.object({
-  type: z.literal('story-opened'),
-  id: z.string().min(1),
+export const HiddenNewsPublishedEventSchema = z.object({
+  type: z.literal('hidden-news-published'),
+  id: z.string().min(1).optional(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  icon: z.enum(ICON_VALUES),
+  title: z.string().min(1),
+  description: z.string().min(1),
 });
 
-export const StoryClosedEventSchema = z.object({
-  type: z.literal('story-closed'),
+export const NewsPatchedEventSchema = z.object({
+  type: z.literal('news-patched'),
   id: z.string().min(1),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  patch: NewsPatchSchema,
 });
 
 export const TurnStartedEventSchema = z.object({
@@ -80,10 +105,23 @@ export const TurnFinishedEventSchema = z.object({
   until: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 
+export const GameOverEventSchema = z.object({
+  type: z.literal('game-over'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  summary: z.string().min(1),
+});
+
+export const ScenarioHeadCompletedEventSchema = z.object({
+  type: z.literal('scenario-head-completed'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
 export const EngineEventSchema = z.discriminatedUnion('type', [
   NewsPublishedEventSchema,
-  StoryOpenedEventSchema,
-  StoryClosedEventSchema,
+  HiddenNewsPublishedEventSchema,
+  NewsPatchedEventSchema,
+  GameOverEventSchema,
+  ScenarioHeadCompletedEventSchema,
   TurnStartedEventSchema,
   TurnFinishedEventSchema,
 ]);

--- a/packages/engine/src/utils/events.ts
+++ b/packages/engine/src/utils/events.ts
@@ -1,6 +1,17 @@
 import { ICON_SET } from '../constants';
 import { slugify } from './strings.js';
-import type { EngineEvent, NewsPublishedEvent, ScenarioEvent, StoryClosedEvent, StoryOpenedEvent } from '../types';
+import type {
+  EngineEvent,
+  GameOverEvent,
+  HiddenNewsPublishedEvent,
+  NewsEvent,
+  NewsPatchedEvent,
+  NewsPublishedEvent,
+  ScenarioEvent,
+  ScenarioHeadCompletedEvent,
+  TurnFinishedEvent,
+  TurnStartedEvent,
+} from '../types';
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const ICONS = new Set<string>(ICON_SET);
@@ -21,8 +32,90 @@ export function isNewsPublishedEvent(value: unknown): value is NewsPublishedEven
     typeof candidate.title === 'string' &&
     candidate.title.trim().length > 0 &&
     typeof candidate.description === 'string' &&
-    candidate.description.trim().length > 0 &&
-    (candidate.postMortem === undefined || typeof candidate.postMortem === 'boolean')
+    candidate.description.trim().length > 0
+  );
+}
+
+export function isHiddenNewsPublishedEvent(value: unknown): value is HiddenNewsPublishedEvent {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<HiddenNewsPublishedEvent>;
+  return (
+    candidate.type === 'hidden-news-published' &&
+    typeof candidate.date === 'string' &&
+    DATE_PATTERN.test(candidate.date) &&
+    typeof candidate.icon === 'string' &&
+    ICONS.has(candidate.icon) &&
+    typeof candidate.title === 'string' &&
+    candidate.title.trim().length > 0 &&
+    typeof candidate.description === 'string' &&
+    candidate.description.trim().length > 0
+  );
+}
+
+export function isNewsPatchedEvent(value: unknown): value is NewsPatchedEvent {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<NewsPatchedEvent>;
+  if (candidate.type !== 'news-patched') return false;
+  if (typeof candidate.id !== 'string' || candidate.id.trim().length === 0) return false;
+  if (typeof candidate.date !== 'string' || !DATE_PATTERN.test(candidate.date)) return false;
+  if (!candidate.patch || typeof candidate.patch !== 'object') return false;
+  const patch = candidate.patch as NewsPatchedEvent['patch'];
+  const hasField = !!patch.date || !!patch.icon || !!patch.title || !!patch.description;
+  if (!hasField) return false;
+  if (patch.date && !DATE_PATTERN.test(patch.date)) return false;
+  if (patch.icon && !ICONS.has(patch.icon)) return false;
+  if (patch.title !== undefined && patch.title.trim().length === 0) return false;
+  if (patch.description !== undefined && patch.description.trim().length === 0) return false;
+  return true;
+}
+
+export function isGameOverEvent(value: unknown): value is GameOverEvent {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<GameOverEvent>;
+  return (
+    candidate.type === 'game-over' &&
+    typeof candidate.date === 'string' &&
+    DATE_PATTERN.test(candidate.date) &&
+    typeof candidate.summary === 'string' &&
+    candidate.summary.trim().length > 0
+  );
+}
+
+export function isScenarioHeadCompletedEvent(
+  value: unknown
+): value is ScenarioHeadCompletedEvent {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<ScenarioHeadCompletedEvent>;
+  return (
+    candidate.type === 'scenario-head-completed' &&
+    typeof candidate.date === 'string' &&
+    DATE_PATTERN.test(candidate.date)
+  );
+}
+
+export function isNewsEvent(value: unknown): value is NewsEvent {
+  return isNewsPublishedEvent(value) || isHiddenNewsPublishedEvent(value);
+}
+
+export function isEngineEvent(value: unknown): value is EngineEvent {
+  return (
+    isNewsPublishedEvent(value) ||
+    isHiddenNewsPublishedEvent(value) ||
+    isNewsPatchedEvent(value) ||
+    isGameOverEvent(value) ||
+    isScenarioHeadCompletedEvent(value) ||
+    isTurnStartedEvent(value) ||
+    isTurnFinishedEvent(value)
   );
 }
 
@@ -31,6 +124,13 @@ export function coerceScenarioEvents(payload: unknown, context: string): Scenari
     throw new Error(`Invalid ScenarioEvent payload from ${context}.`);
   }
   return sortAndDedupEvents(payload) as ScenarioEvent[];
+}
+
+export function coerceEngineEvents(payload: unknown, context: string): EngineEvent[] {
+  if (!Array.isArray(payload) || !payload.every(isEngineEvent)) {
+    throw new Error(`Invalid EngineEvent payload from ${context}.`);
+  }
+  return sortAndDedupEvents(payload) as EngineEvent[];
 }
 
 export function sortAndDedupEvents<T extends EngineEvent>(events: T[]): T[] {
@@ -56,29 +156,30 @@ export function nextDateAfter(history: EngineEvent[]): string {
   return date.toISOString().split('T')[0];
 }
 
-export function assertChronology(history: ScenarioEvent[], additions: ScenarioEvent[]): void {
-  const lastDate = history[history.length - 1]?.date;
+export function assertChronology(history: EngineEvent[], additions: EngineEvent[]): void {
+  const lastDate = history.length ? eventDate(history[history.length - 1]) : null;
   if (!lastDate) return;
-  const invalid = additions.find(evt => evt.date < lastDate);
+  const invalid = additions.find(evt => eventDate(evt) < lastDate);
   if (invalid) {
-    throw new Error(`Model returned an event with a past date: ${invalid.date}`);
+    throw new Error(`Model returned an event with a past date: ${eventDate(invalid)}`);
   }
 }
 
 function normalizeEvent(event: EngineEvent): EngineEvent {
   switch (event.type) {
-    case 'story-opened':
-      return {
-        ...event,
-        id: event.id ?? `story-opened-${slugify(event.date)}`,
-      };
-    case 'story-closed':
-      return {
-        ...event,
-        id: event.id ?? `story-closed-${slugify(event.date)}`,
-      };
     case 'turn-started':
     case 'turn-finished':
+      return event;
+    case 'hidden-news-published': {
+      const news = event as HiddenNewsPublishedEvent;
+      return {
+        ...news,
+        id: news.id ?? `hidden-news-${news.date}-${slugify(news.title)}`,
+      };
+    }
+    case 'news-patched':
+    case 'game-over':
+    case 'scenario-head-completed':
       return event;
     case 'news-published':
     default: {
@@ -93,11 +194,11 @@ function normalizeEvent(event: EngineEvent): EngineEvent {
 }
 
 function getTitle(event: EngineEvent): string {
-  if (event.type === 'news-published') {
-    return (event as NewsPublishedEvent).title;
-  }
-  if (event.type === 'story-opened') return `story-opened-${event.id}`;
-  if (event.type === 'story-closed') return `story-closed-${event.id}`;
+  if (event.type === 'news-published') return (event as NewsPublishedEvent).title;
+  if (event.type === 'hidden-news-published') return (event as HiddenNewsPublishedEvent).title;
+  if (event.type === 'news-patched') return `news-patched-${event.id}`;
+  if (event.type === 'game-over') return `game-over-${event.summary}`;
+  if (event.type === 'scenario-head-completed') return 'scenario-head-completed';
   if (event.type === 'turn-started') return `turn-started-${event.from}-${event.until}`;
   if (event.type === 'turn-finished') return `turn-finished-${event.from}-${event.until}`;
   return 'event';
@@ -105,14 +206,26 @@ function getTitle(event: EngineEvent): string {
 
 function dedupKey(event: EngineEvent): string {
   switch (event.type) {
-    case 'story-opened':
-      return `story-opened-${event.id ?? 'missing'}-${event.date}`;
-    case 'story-closed':
-      return `story-closed-${event.id ?? 'missing'}-${event.date}`;
     case 'turn-started':
       return `turn-started-${event.from}-${event.until}-${event.actor}`;
     case 'turn-finished':
       return `turn-finished-${event.from}-${event.until}-${event.actor}`;
+    case 'hidden-news-published': {
+      const news = event as HiddenNewsPublishedEvent;
+      return `hidden-news-${news.date}-${news.title}`.toLowerCase();
+    }
+    case 'news-patched': {
+      const patch = event as NewsPatchedEvent;
+      return `news-patched-${patch.id}-${patch.date}-${JSON.stringify(patch.patch)}`;
+    }
+    case 'game-over': {
+      const gameOver = event as GameOverEvent;
+      return `game-over-${gameOver.date}-${gameOver.summary}`.toLowerCase();
+    }
+    case 'scenario-head-completed': {
+      const boundary = event as ScenarioHeadCompletedEvent;
+      return `scenario-head-completed-${boundary.date}`;
+    }
     case 'news-published':
     default: {
       const news = event as NewsPublishedEvent;
@@ -127,10 +240,36 @@ function eventDate(event: EngineEvent): string {
   return '1970-01-01';
 }
 
-function hasDate(
-  event: EngineEvent
-): event is NewsPublishedEvent | StoryClosedEvent | StoryOpenedEvent {
+function hasDate(event: EngineEvent): event is NewsPublishedEvent | HiddenNewsPublishedEvent | NewsPatchedEvent | GameOverEvent | ScenarioHeadCompletedEvent {
   return 'date' in event && typeof (event as NewsPublishedEvent).date === 'string';
+}
+
+function isTurnStartedEvent(value: unknown): value is TurnStartedEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<TurnStartedEvent>;
+  return (
+    candidate.type === 'turn-started' &&
+    typeof candidate.actor === 'string' &&
+    (candidate.actor === 'player' || candidate.actor === 'game_master') &&
+    typeof candidate.from === 'string' &&
+    DATE_PATTERN.test(candidate.from) &&
+    typeof candidate.until === 'string' &&
+    DATE_PATTERN.test(candidate.until)
+  );
+}
+
+function isTurnFinishedEvent(value: unknown): value is TurnFinishedEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<TurnFinishedEvent>;
+  return (
+    candidate.type === 'turn-finished' &&
+    typeof candidate.actor === 'string' &&
+    (candidate.actor === 'player' || candidate.actor === 'game_master') &&
+    typeof candidate.from === 'string' &&
+    DATE_PATTERN.test(candidate.from) &&
+    typeof candidate.until === 'string' &&
+    DATE_PATTERN.test(candidate.until)
+  );
 }
 
 // Back-compat alias for existing callers.

--- a/packages/engine/src/utils/normalize.ts
+++ b/packages/engine/src/utils/normalize.ts
@@ -1,5 +1,10 @@
 import { slugify } from './strings.js';
-import type { PublishNewsCommand, NewsPublishedEvent } from '../types.js';
+import type {
+  PublishNewsCommand,
+  PublishHiddenNewsCommand,
+  NewsPublishedEvent,
+  HiddenNewsPublishedEvent,
+} from '../types.js';
 
 /**
  * Normalizes a PublishNewsCommand into a NewsPublishedEvent with ids/types filled.
@@ -12,6 +17,21 @@ export function normalizePublishNews(cmd: PublishNewsCommand): NewsPublishedEven
     icon: cmd.icon,
     title: cmd.title,
     description: cmd.description,
-    postMortem: cmd.postMortem,
+  };
+}
+
+/**
+ * Normalizes a PublishHiddenNewsCommand into a HiddenNewsPublishedEvent with ids/types filled.
+ */
+export function normalizePublishHiddenNews(
+  cmd: PublishHiddenNewsCommand
+): HiddenNewsPublishedEvent {
+  return {
+    type: 'hidden-news-published',
+    id: cmd.id ?? `hidden-news-${cmd.date}-${slugify(cmd.title)}`,
+    date: cmd.date,
+    icon: cmd.icon,
+    title: cmd.title,
+    description: cmd.description,
   };
 }

--- a/packages/engine/src/utils/promptProjector.ts
+++ b/packages/engine/src/utils/promptProjector.ts
@@ -1,18 +1,22 @@
-import type { EngineEvent, NewsPublishedEvent, TurnStartedEvent } from '../types.js';
+import type {
+  EngineEvent,
+  HiddenNewsPublishedEvent,
+  NewsPatchedEvent,
+  NewsPublishedEvent,
+  ScenarioHeadCompletedEvent,
+} from '../types.js';
 
 interface ProjectionInput {
   history: EngineEvent[];
-  seedHistoryEndDate?: string;
 }
 
 /**
  * Projects the append-only event log into a prompt-friendly string:
- * - JSONL timeline including turn markers and news-published events.
- * - Player turn story-opens are collapsed into a single NewsOpened line per player turn.
+ * - JSONL timeline including turn markers, news events, and patch/boundary markers.
  * - A small dynamic block with latest date and current turn window.
  */
 export function projectPrompt(input: ProjectionInput): string {
-  const { timelineLines, dynamic } = buildTimeline(input.history, input.seedHistoryEndDate);
+  const { timelineLines, dynamic } = buildTimeline(input.history);
   return [
     '# TIMELINE (JSONL)',
     ...timelineLines,
@@ -21,34 +25,19 @@ export function projectPrompt(input: ProjectionInput): string {
   ].join('\n');
 }
 
-function buildTimeline(history: EngineEvent[], seedHistoryEndDate?: string) {
+function buildTimeline(history: EngineEvent[]) {
   const lines: string[] = [];
-  let currentPlayerTurn: TurnStartedEvent | null = null;
-  let openedInTurn: Set<string> = new Set();
   let cutoffInserted = false;
 
   let latestDate: string | null = null;
   let currentTurn: { from: string; until: string; actor: string } | null = null;
 
-  const flushOpened = () => {
-    if (currentPlayerTurn && openedInTurn.size > 0) {
-      lines.push(
-        JSON.stringify({
-          type: 'news-opened',
-          turn: { from: currentPlayerTurn.from, until: currentPlayerTurn.until },
-          ids: [...openedInTurn],
-        })
-      );
-      openedInTurn = new Set();
-    }
-  };
-
-  const insertCutoffMarker = () => {
-    if (!seedHistoryEndDate || cutoffInserted) return;
+  const insertCutoffMarker = (event: ScenarioHeadCompletedEvent) => {
+    if (cutoffInserted) return;
     lines.push(
       JSON.stringify({
         type: 'forecast-cutoff',
-        date: seedHistoryEndDate,
+        date: event.date,
         note: 'Seed history ends here; forecast begins here (not a model knowledge cutoff).',
       })
     );
@@ -60,32 +49,13 @@ function buildTimeline(history: EngineEvent[], seedHistoryEndDate?: string) {
       latestDate = evt.date;
     }
 
-    const boundaryDate =
-      'date' in evt && typeof evt.date === 'string'
-        ? evt.date
-        : evt.type === 'turn-started' || evt.type === 'turn-finished'
-          ? evt.from
-          : null;
-
-    if (seedHistoryEndDate && boundaryDate && boundaryDate > seedHistoryEndDate && !cutoffInserted) {
-      insertCutoffMarker();
-    }
-
     switch (evt.type) {
       case 'turn-started': {
         currentTurn = { from: evt.from, until: evt.until, actor: evt.actor };
-        if (evt.actor === 'player') {
-          flushOpened();
-          currentPlayerTurn = evt;
-        }
         lines.push(JSON.stringify(evt));
         break;
       }
       case 'turn-finished': {
-        if (evt.actor === 'player') {
-          flushOpened();
-          currentPlayerTurn = null;
-        }
         currentTurn = null;
         lines.push(JSON.stringify(evt));
         break;
@@ -94,24 +64,23 @@ function buildTimeline(history: EngineEvent[], seedHistoryEndDate?: string) {
         lines.push(JSON.stringify(evt as NewsPublishedEvent));
         break;
       }
-      case 'story-opened': {
-        if (currentPlayerTurn) {
-          openedInTurn.add(evt.id);
-        }
+      case 'hidden-news-published': {
+        lines.push(JSON.stringify(evt as HiddenNewsPublishedEvent));
         break;
       }
-      case 'story-closed':
-        // ignored in prompt; still kept in history
+      case 'news-patched': {
+        lines.push(JSON.stringify(evt as NewsPatchedEvent));
         break;
+      }
+      case 'scenario-head-completed': {
+        const boundary = evt as ScenarioHeadCompletedEvent;
+        lines.push(JSON.stringify(boundary));
+        insertCutoffMarker(boundary);
+        break;
+      }
       default:
         lines.push(JSON.stringify(evt));
     }
-  }
-
-  // If player turn open at end, flush it too.
-  flushOpened();
-  if (seedHistoryEndDate && !cutoffInserted) {
-    insertCutoffMarker();
   }
 
   const dynamic = {

--- a/packages/engine/test/utils.test.ts
+++ b/packages/engine/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { coerceScenarioEvents, sortAndDedupEvents, nextDateAfter } from '../src/utils/events.js';
+import { coerceScenarioEvents, coerceEngineEvents, sortAndDedupEvents, nextDateAfter } from '../src/utils/events.js';
 import { ICON_SET } from '../src/constants.js';
 
 const baseEvent = {
@@ -13,6 +13,14 @@ describe('event utils', () => {
   it('coerces valid payloads', () => {
     const result = coerceScenarioEvents([baseEvent], 'test');
     expect(result).toHaveLength(1);
+  });
+
+  it('coerces engine events with scenario boundary', () => {
+    const result = coerceEngineEvents(
+      [baseEvent, { type: 'scenario-head-completed', date: '2025-01-01' }],
+      'test'
+    );
+    expect(result).toHaveLength(2);
   });
 
   it('sorts and dedups by date-title', () => {

--- a/packages/webapp/src/components/ComposePanel.tsx
+++ b/packages/webapp/src/components/ComposePanel.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { ScenarioEvent } from '../types';
+import type { NewsPublishedEvent } from '../types';
 import { Icon } from './icons';
 import { ICON_SET, type IconName } from '../constants';
 
 interface ComposePanelProps {
   latestDate: string;
-  onSubmit: (event: ScenarioEvent) => void;
+  onSubmit: (event: NewsPublishedEvent) => void;
   isLoading: boolean;
 }
 
@@ -42,7 +42,7 @@ export const ComposePanel: React.FC<ComposePanelProps> = ({ latestDate, onSubmit
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !description.trim() || isLoading) return;
-    onSubmit({ type: 'news-published', date, icon, title, description, postMortem: false });
+    onSubmit({ type: 'news-published', date, icon, title, description });
     setTitle('');
     setDescription('');
   };

--- a/packages/webapp/src/components/EventItem.tsx
+++ b/packages/webapp/src/components/EventItem.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { ScenarioEvent } from '../types';
+import type { NewsPublishedEvent } from '../types';
 import { Icon } from './icons';
 
 interface EventItemProps {
-  event: ScenarioEvent;
+  event: NewsPublishedEvent;
   searchQuery?: string;
   isLast: boolean;
 }
@@ -34,16 +34,15 @@ const highlightText = (text: string, highlight: string) => {
 
 export const EventItem: React.FC<EventItemProps> = ({ event, searchQuery = '', isLast }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const isPostMortem = event.postMortem === true;
 
   return (
     <div className="flex items-start">
       {/* Icon Gutter */}
       <div className="w-12 flex-shrink-0 flex justify-center pt-1">
-        <div className={`p-1 rounded-full ${isPostMortem ? 'bg-amber-100' : 'bg-beige-50'}`}>
+        <div className="p-1 rounded-full bg-beige-50">
           <Icon
             name={event.icon}
-            className={`w-5 h-5 ${isPostMortem ? 'text-amber-700' : 'text-stone-600'}`}
+            className="w-5 h-5 text-stone-600"
           />
         </div>
       </div>
@@ -55,17 +54,12 @@ export const EventItem: React.FC<EventItemProps> = ({ event, searchQuery = '', i
         aria-expanded={isExpanded}
       >
         <div className="flex items-center gap-2 pt-1">
-          <h3 className={`font-medium leading-tight ${isPostMortem ? 'text-amber-800' : 'text-stone-800'}`}>
+          <h3 className="font-medium leading-tight text-stone-800">
             {highlightText(event.title, searchQuery)}
           </h3>
-          {isPostMortem && (
-            <span className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-              Post-Mortem
-            </span>
-          )}
         </div>
         {isExpanded && (
-          <div className={`mt-2 leading-relaxed ${isPostMortem ? 'text-amber-900' : 'text-stone-600'}`}>
+          <div className="mt-2 leading-relaxed text-stone-600">
             {highlightText(event.description, searchQuery)}
           </div>
         )}

--- a/packages/webapp/src/components/FileControls.tsx
+++ b/packages/webapp/src/components/FileControls.tsx
@@ -1,11 +1,11 @@
 import React, { useRef } from 'react';
 import { Icon } from './icons';
-import { ScenarioEvent } from '../types';
-import { coerceScenarioEvents } from '../utils/events';
+import type { EngineEvent } from '../types';
+import { coerceEngineEvents } from '../utils/events';
 
 interface FileControlsProps {
-    events: ScenarioEvent[];
-    onImport: (newEvents: ScenarioEvent[]) => void;
+    events: EngineEvent[];
+    onImport: (newEvents: EngineEvent[]) => void;
 }
 
 export const FileControls: React.FC<FileControlsProps> = ({ events, onImport }) => {
@@ -35,7 +35,7 @@ export const FileControls: React.FC<FileControlsProps> = ({ events, onImport }) 
                 const text = e.target?.result;
                 if (typeof text !== 'string') throw new Error("File is not readable");
                 const parsedEvents = JSON.parse(text);
-                const validatedEvents = coerceScenarioEvents(parsedEvents, file.name || 'imported file');
+                const validatedEvents = coerceEngineEvents(parsedEvents, file.name || 'imported file');
                 if (window.confirm("Replace current timeline with the imported one?")) {
                    onImport(validatedEvents);
                 }

--- a/packages/webapp/src/components/Header.tsx
+++ b/packages/webapp/src/components/Header.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Icon } from './icons';
 import { FileControls } from './FileControls';
-import { ScenarioEvent } from '../types';
+import type { EngineEvent } from '../types';
 
 interface HeaderProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
-  events: ScenarioEvent[];
-  onImport: (newEvents: ScenarioEvent[]) => void;
+  events: EngineEvent[];
+  onImport: (newEvents: EngineEvent[]) => void;
 }
 
 export const Header: React.FC<HeaderProps> = ({ searchQuery, onSearchChange, events, onImport }) => {

--- a/packages/webapp/src/components/Timeline.tsx
+++ b/packages/webapp/src/components/Timeline.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { ScenarioEvent } from '../types';
+import type { NewsPublishedEvent } from '../types';
 import { EventItem } from './EventItem';
 
 interface TimelineProps {
-  events: ScenarioEvent[];
+  events: NewsPublishedEvent[];
   searchQuery: string;
-  seedHistoryEndDate?: string;
+  boundaryDate?: string | null;
 }
 
 const YearMarker: React.FC<{ year: string }> = ({ year }) => (
@@ -33,7 +33,7 @@ const ForecastMarker: React.FC<{ date: string }> = ({ date }) => (
       <span className="ml-3 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-amber-700 bg-beige-50 px-2 py-1 rounded">
         Forecast begins
       </span>
-      <span className="ml-2 text-xs text-stone-500">Seed history ends {date}</span>
+      <span className="ml-2 text-xs text-stone-500">Scenario head ends {date}</span>
     </div>
   </div>
 );
@@ -43,16 +43,11 @@ const getMonthName = (dateStr: string) => {
     return date.toLocaleString('en-US', { month: 'short' });
 };
 
-export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, seedHistoryEndDate }) => {
-  const visibleEvents = React.useMemo(
-    () => events.filter(event => !event.postMortem),
-    [events]
-  );
-
+export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, boundaryDate }) => {
   // Create a nested structure for years and months to scope sticky headers.
   // The original `events` array is pre-sorted, so insertion order is chronological.
-  const structuredTimeline: Record<string, Record<string, ScenarioEvent[]>> = {};
-  visibleEvents.forEach(event => {
+  const structuredTimeline: Record<string, Record<string, NewsPublishedEvent[]>> = {};
+  events.forEach(event => {
     const year = event.date.substring(0, 4);
     const month = getMonthName(event.date);
     if (!structuredTimeline[year]) {
@@ -64,7 +59,7 @@ export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, seedHis
     structuredTimeline[year][month].push(event);
   });
 
-  const lastEvent = visibleEvents.length > 0 ? visibleEvents[visibleEvents.length - 1] : null;
+  const lastEvent = events.length > 0 ? events[events.length - 1] : null;
 
   let cutoffInserted = false;
 
@@ -79,12 +74,12 @@ export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, seedHis
               {monthEvents.flatMap((event, index) => {
                 const items: React.ReactNode[] = [];
                 if (
-                  seedHistoryEndDate &&
+                  boundaryDate &&
                   !cutoffInserted &&
-                  event.date > seedHistoryEndDate
+                  event.date > boundaryDate
                 ) {
                   items.push(
-                    <ForecastMarker key={`forecast-marker-${seedHistoryEndDate}`} date={seedHistoryEndDate} />
+                    <ForecastMarker key={`forecast-marker-${boundaryDate}`} date={boundaryDate} />
                   );
                   cutoffInserted = true;
                 }
@@ -102,8 +97,8 @@ export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, seedHis
           ))}
         </div>
       ))}
-      {seedHistoryEndDate && !cutoffInserted && (
-        <ForecastMarker date={seedHistoryEndDate} />
+      {boundaryDate && !cutoffInserted && (
+        <ForecastMarker date={boundaryDate} />
       )}
     </div>
   );

--- a/packages/webapp/src/data/index.ts
+++ b/packages/webapp/src/data/index.ts
@@ -1,10 +1,4 @@
 import rawInitialEvents from './initialScenarioEvents.json';
-import { coerceScenarioEvents } from '@ai-forecasting/engine';
+import { coerceEngineEvents } from '@ai-forecasting/engine';
 
-export const INITIAL_EVENTS = coerceScenarioEvents(rawInitialEvents, 'initial scenario seed');
-
-export const SEED_END_DATE = INITIAL_EVENTS.length
-  ? INITIAL_EVENTS.reduce<string>((latest, event) => {
-      return event.date > latest ? event.date : latest;
-    }, INITIAL_EVENTS[0].date)
-  : undefined;
+export const INITIAL_EVENTS = coerceEngineEvents(rawInitialEvents, 'initial scenario seed');

--- a/packages/webapp/src/data/initialScenarioEvents.json
+++ b/packages/webapp/src/data/initialScenarioEvents.json
@@ -226,5 +226,9 @@
     "icon": "Power",
     "title": "EU agrees to phase out Russian gas and oil by 2028; Russian gas share ~12–13% in 2025",
     "description": "EU energy ministers back a regulation to end Russian fossil imports by Jan 1, 2028 (subject to Parliament). Despite progress, Russian gas (including LNG) remains ~12–13% of EU imports in 2025, with variation by member state."
+  },
+  {
+    "type": "scenario-head-completed",
+    "date": "2025-10-30"
   }
 ]

--- a/packages/webapp/src/services/geminiService.ts
+++ b/packages/webapp/src/services/geminiService.ts
@@ -1,15 +1,15 @@
 
 import { createBrowserForecaster, createEngine, SYSTEM_PROMPT } from '@ai-forecasting/engine';
 import type { ForecasterOptions } from '@ai-forecasting/engine';
-import type { ScenarioEvent } from '../types';
+import type { EngineEvent } from '../types';
 
 const forecaster = createBrowserForecaster({ apiKey: import.meta.env.GEMINI_API_KEY });
 const engine = createEngine({ forecaster, systemPrompt: SYSTEM_PROMPT });
 
 // PLACEHOLDER LOGIC: thin wrapper that delegates to the engine; no retries/chunking yet.
 export async function getAiForecast(
-  history: ScenarioEvent[],
+  history: EngineEvent[],
   options?: ForecasterOptions
-): Promise<ScenarioEvent[]> {
+): Promise<EngineEvent[]> {
   return engine.forecast(history, options);
 }

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -1,1 +1,1 @@
-export type { NewsPublishedEvent as ScenarioEvent } from '@ai-forecasting/engine';
+export type { EngineEvent, NewsPublishedEvent } from '@ai-forecasting/engine';

--- a/packages/webapp/src/utils/events.ts
+++ b/packages/webapp/src/utils/events.ts
@@ -1,2 +1,43 @@
 // Re-export engine utils so webapp continues to import from this path.
-export { coerceScenarioEvents, sortAndDedupEvents } from '@ai-forecasting/engine';
+import type { EngineEvent, NewsEvent, NewsPublishedEvent } from '@ai-forecasting/engine';
+import { coerceEngineEvents, sortAndDedupEvents } from '@ai-forecasting/engine';
+
+export { coerceEngineEvents, sortAndDedupEvents };
+
+export function getScenarioHeadDate(events: EngineEvent[]): string | null {
+  const sorted = sortAndDedupEvents(events);
+  const boundary = [...sorted].reverse().find(event => event.type === 'scenario-head-completed');
+  return boundary && 'date' in boundary ? boundary.date : null;
+}
+
+export function materializeNewsEvents(events: EngineEvent[]): NewsEvent[] {
+  const sorted = sortAndDedupEvents(events);
+  const byId = new Map<string, NewsEvent>();
+
+  for (const event of sorted) {
+    if (event.type === 'news-published' || event.type === 'hidden-news-published') {
+      if (!event.id) continue;
+      byId.set(event.id, event);
+      continue;
+    }
+
+    if (event.type === 'news-patched') {
+      const target = byId.get(event.id);
+      if (!target) continue;
+      const updated: NewsEvent = {
+        ...target,
+        ...event.patch,
+        type: target.type,
+        id: target.id,
+      };
+      byId.set(event.id, updated);
+    }
+  }
+
+  return sortAndDedupEvents([...byId.values()]) as NewsEvent[];
+}
+
+export function getVisibleNews(events: EngineEvent[]): NewsPublishedEvent[] {
+  const materialized = materializeNewsEvents(events);
+  return materialized.filter(event => event.type === 'news-published') as NewsPublishedEvent[];
+}


### PR DESCRIPTION
## Summary
- implement Contract v2 command/event contract end-to-end (hidden news, patch-news, game-over, scenario-head-completed) across engine + webapp + CLI

## Task(s)
- Closes #17
- Closes #9

## Changes
- Engine: update command/event types + schemas, prompt projection, response schema tightening, and seed boundary event handling.
  - `packages/engine/src/types.ts`
  - `packages/engine/src/schemas.ts`
  - `packages/engine/src/constants.ts`
  - `packages/engine/src/utils/events.ts`
  - `packages/engine/src/utils/promptProjector.ts`
  - `packages/engine/src/forecaster/geminiStreaming.ts`
  - `packages/engine/src/forecaster/streamingPipeline.ts`
  - `packages/engine/src/data/initialScenarioEvents.json`
- Webapp: persist full EngineEvent log, apply patch events for display, hide hidden news, and render the head/body split from `scenario-head-completed` (with storage key bump).
  - `packages/webapp/src/App.tsx`
  - `packages/webapp/src/utils/events.ts`
  - `packages/webapp/src/components/Timeline.tsx`
  - `packages/webapp/src/data/initialScenarioEvents.json`
- CLI/tests: update prompt guidance + parse mapping + tests for patch commands.
  - `packages/cli/src/commands/prepare.ts`
  - `packages/cli/src/commands/parse.ts`
  - `packages/cli/test/parse.test.ts`

## Testing and Quality Assurance
- `npm run check`

## Risks / notes
- Local storage key bumped to `takeoff-timeline-events-v2`, so existing saves are ignored by design.
- Patch events only apply when the target news id exists; missing targets are skipped.

## Remaining work
- None.

---
Written-by: codex agent running in worktree /workspaces/worktrees/20260101-contract-v2-a
