### PR TITLE
Contract v2 event log + hidden news

### DIFF
--- a/packages/cli/src/commands/eventIo.ts
+++ b/packages/cli/src/commands/eventIo.ts
@@ -1,7 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import {
   EngineEventSchema,
-  ScenarioEventSchema,
   sortAndDedupEvents,
   type EngineEvent,
 } from '@ai-forecasting/engine';
@@ -41,19 +40,9 @@ export function formatZodIssues(issues: Issue[]): string {
 }
 
 function parseEvent(payload: unknown, label: string, lineNumber: number): EngineEvent {
-  if (payload && typeof payload === 'object' && typeof (payload as { type?: unknown }).type === 'string') {
-    const raw = payload as Record<string, unknown>;
-    const normalized = raw.type === 'news' ? { ...raw, type: 'news-published' } : raw;
-    const result = EngineEventSchema.safeParse(normalized);
-    if (result.success) return result.data;
-    throw new Error(
-      `${label}: invalid engine event on line ${lineNumber}.\n${formatZodIssues(result.error.issues)}`
-    );
-  }
-
-  const scenario = ScenarioEventSchema.safeParse(payload);
-  if (scenario.success) return scenario.data as EngineEvent;
+  const result = EngineEventSchema.safeParse(payload);
+  if (result.success) return result.data;
   throw new Error(
-    `${label}: invalid scenario event on line ${lineNumber}.\n${formatZodIssues(scenario.error.issues)}`
+    `${label}: invalid engine event on line ${lineNumber}.\n${formatZodIssues(result.error.issues)}`
   );
 }

--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -5,6 +5,8 @@ import {
   type Command,
   type EngineEvent,
   normalizePublishNews,
+  normalizePublishHiddenNews,
+  normalizePatchNews,
 } from '@ai-forecasting/engine';
 import { formatZodIssues, writeEventsJsonl } from './eventIo.js';
 
@@ -86,10 +88,12 @@ function commandToEvents(cmd: Command): EngineEvent[] {
   switch (cmd.type) {
     case 'publish-news':
       return [normalizePublishNews(cmd)];
-    case 'open-story':
-      return [{ type: 'story-opened', id: cmd.refId, date: cmd.date }];
-    case 'close-story':
-      return [{ type: 'story-closed', id: cmd.refId, date: cmd.date }];
+    case 'publish-hidden-news':
+      return [normalizePublishHiddenNews(cmd)];
+    case 'patch-news':
+      return [normalizePatchNews(cmd)];
+    case 'game-over':
+      return [{ type: 'game-over', date: cmd.date, summary: cmd.summary }];
     default:
       return [];
   }

--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -14,13 +14,13 @@ YOU RECEIVE:
 YOU OUTPUT:
 - Strictly a JSON array of Command objects (no extra text, no markdown).
 - Command schema:
-  - publish-news: { type: "publish-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string, postMortem?: boolean }
-  - open-story: { type: "open-story", refId: string, date: "YYYY-MM-DD" }
-  - close-story: { type: "close-story", refId: string, date: "YYYY-MM-DD" }
+  - publish-news: { type: "publish-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
+  - publish-hidden-news: { type: "publish-hidden-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
+  - patch-news: { type: "patch-news", targetId: string, date: "YYYY-MM-DD", patch: { title?: string, description?: string, icon?: IconName, date?: "YYYY-MM-DD" } }
+  - game-over: { type: "game-over", date: "YYYY-MM-DD", summary: string }
 - All command dates must be on or after the latest date in history.
 - For publish-news.icon, use a valid icon name from the Lucide icon library in PascalCase (e.g., "Landmark").
 - Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
-- Include postMortem: true only for events that should stay hidden until post-mortem review.
 - Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
 - Aim for 1–5 commands per turn to preserve alternation pacing.
 

--- a/packages/cli/test/parse.test.ts
+++ b/packages/cli/test/parse.test.ts
@@ -19,9 +19,10 @@ describe('runParse', () => {
         description: 'Test description',
       },
       {
-        type: 'open-story',
-        refId: 'story-1',
-        date: '2025-01-02',
+        type: 'patch-news',
+        targetId: 'news-2025-01-02-test-headline',
+        date: '2025-01-03',
+        patch: { title: 'Updated headline' },
       },
     ];
 
@@ -37,9 +38,9 @@ describe('runParse', () => {
       title: 'Test headline',
     });
     expect(events[1]).toMatchObject({
-      type: 'story-opened',
-      id: 'story-1',
-      date: '2025-01-02',
+      type: 'news-patched',
+      targetId: 'news-2025-01-02-test-headline',
+      date: '2025-01-03',
     });
   });
 });

--- a/packages/engine/src/adapters/geminiBrowserForecaster.ts
+++ b/packages/engine/src/adapters/geminiBrowserForecaster.ts
@@ -1,8 +1,7 @@
 import { GoogleGenAI } from '@google/genai';
-import type { Forecaster, ForecasterContext, ForecasterOptions, ScenarioEvent } from '../types.js';
+import type { Forecaster, ForecasterContext, ForecasterOptions, EngineEvent } from '../types.js';
 import { streamGeminiRaw, type GenAIClient } from '../forecaster/geminiStreaming.js';
 import { parseActionChunk } from '../forecaster/streamingPipeline.js';
-import { isNewsPublishedEvent } from '../utils/events.js';
 
 interface BrowserForecasterConfig {
   apiKey: string | undefined;
@@ -26,14 +25,12 @@ export function createBrowserForecaster(config: BrowserForecasterConfig): Foreca
         throw new Error('GEMINI_API_KEY is missing. Add it to your .env.local or hosting env.');
       }
 
-      // Only send news events to the model; UI events like story-opened are omitted.
-      let history = context.history.filter(isNewsPublishedEvent) as ScenarioEvent[];
-      const events: ScenarioEvent[] = [];
+      let history = context.history;
+      const events: EngineEvent[] = [];
       for await (const raw of streamGeminiRaw({ client: ai as unknown as GenAIClient, model, history, systemPrompt: context.systemPrompt, options })) {
         const { events: batch, nextHistory } = parseActionChunk({ actionsJsonl: raw }, history);
-        const newsOnly = batch.filter(isNewsPublishedEvent) as ScenarioEvent[];
-        events.push(...newsOnly);
-        history = nextHistory.filter(isNewsPublishedEvent) as ScenarioEvent[];
+        events.push(...batch);
+        history = nextHistory;
       }
       return events;
     },

--- a/packages/engine/src/adapters/geminiNodeForecaster.ts
+++ b/packages/engine/src/adapters/geminiNodeForecaster.ts
@@ -1,8 +1,7 @@
 import { GoogleGenAI } from '@google/genai';
-import type { Forecaster, ForecasterContext, ForecasterOptions, ScenarioEvent } from '../types.js';
+import type { Forecaster, ForecasterContext, ForecasterOptions, EngineEvent } from '../types.js';
 import { streamGeminiRaw, type GenAIClient } from '../forecaster/geminiStreaming.js';
 import { parseActionChunk } from '../forecaster/streamingPipeline.js';
-import { isNewsPublishedEvent } from '../utils/events.js';
 
 interface NodeForecasterConfig {
   apiKey?: string;
@@ -26,14 +25,12 @@ export function createNodeForecaster(config: NodeForecasterConfig = {}): Forecas
         throw new Error('GEMINI_API_KEY is missing. Export it before running the CLI.');
       }
 
-      // Only send news events to the model; UI events like story-opened are omitted.
-      let history = context.history.filter(isNewsPublishedEvent) as ScenarioEvent[];
-      const events: ScenarioEvent[] = [];
+      let history = context.history;
+      const events: EngineEvent[] = [];
       for await (const raw of streamGeminiRaw({ client: ai as unknown as GenAIClient, model, history, systemPrompt: context.systemPrompt, options })) {
         const { events: batch, nextHistory } = parseActionChunk({ actionsJsonl: raw }, history);
-        const newsOnly = batch.filter(isNewsPublishedEvent) as ScenarioEvent[];
-        events.push(...newsOnly);
-        history = nextHistory.filter(isNewsPublishedEvent) as ScenarioEvent[];
+        events.push(...batch);
+        history = nextHistory;
       }
       return events;
     },

--- a/packages/engine/src/adapters/mockForecaster.ts
+++ b/packages/engine/src/adapters/mockForecaster.ts
@@ -1,4 +1,4 @@
-import type { Forecaster, ForecasterContext, ScenarioEvent } from '../types.js';
+import type { Forecaster, ForecasterContext, EngineEvent } from '../types.js';
 import { nextDateAfter } from '../utils/events.js';
 
 export interface MockForecasterOptions {
@@ -11,7 +11,7 @@ export function createMockForecaster(opts: MockForecasterOptions = {}): Forecast
 
   return {
     name: 'mock',
-    async forecast(context: ForecasterContext): Promise<ScenarioEvent[]> {
+    async forecast(context: ForecasterContext): Promise<EngineEvent[]> {
       const nextDate = nextDateAfter(context.history);
       // PLACEHOLDER LOGIC: deterministic single event to keep flows testable without real AI.
       return [
@@ -22,7 +22,6 @@ export function createMockForecaster(opts: MockForecasterOptions = {}): Forecast
           icon: 'BrainCircuit',
           title: `${label} forecast event`,
           description: 'Placeholder forecast — replace with real model output when running with Gemini.',
-          postMortem: false,
         },
       ];
     },

--- a/packages/engine/src/constants.ts
+++ b/packages/engine/src/constants.ts
@@ -34,18 +34,20 @@ export const SYSTEM_PROMPT = `SYSTEM ROLE: Simulation engine for an AI takeoff t
 
 YOU RECEIVE:
 - A projected prompt with a JSONL timeline and a dynamic block.
-- Timeline lines include events (news-published, turn-started/finished) plus a forecast cutoff marker:
-  { "type": "forecast-cutoff", "date": "YYYY-MM-DD", "note": "Seed history ends here; forecast begins here (not a model knowledge cutoff)." }
+- Timeline lines include events such as news-published, hidden-news-published, news-patched,
+  scenario-head-completed, turn-started/finished, and game-over.
 - The user controls ONE organization. Default: the United States government and military. The user sets macroscopic agendas only. Do not author decisions for that organization.
 
 YOU OUTPUT:
 - Strictly a JSON array of one or more Command objects (no extra text, no markdown).
-- Command types: "publish-news", "open-story", "close-story". Prefer "publish-news" unless you must open/close a story.
-- For "publish-news": { "type": "publish-news", "date": "YYYY-MM-DD", "icon": "LucideIconName", "title": "string", "description": "string", "postMortem"?: boolean }.
+- Command types: "publish-news", "publish-hidden-news", "patch-news", "game-over".
+- For "publish-news": { "type": "publish-news", "date": "YYYY-MM-DD", "icon": "LucideIconName", "title": "string", "description": "string" }.
+- For "publish-hidden-news": { "type": "publish-hidden-news", "date": "YYYY-MM-DD", "icon": "LucideIconName", "title": "string", "description": "string" }.
+- For "patch-news": { "type": "patch-news", "targetId": "string", "date": "YYYY-MM-DD", "patch": { "title"?: "string", "description"?: "string", "icon"?: "LucideIconName", "date"?: "YYYY-MM-DD" } }.
+- For "game-over": { "type": "game-over", "date": "YYYY-MM-DD", "summary": "string" }.
 - All output dates must be on or after the latest date in history (see dynamic.latestDate).
 - For the "icon" field, use a valid icon name from the Lucide icon library (lucide.dev). The name must be in PascalCase, for example: "Landmark", "BrainCircuit", "FlaskConical", "Cpu", "Satellite".
 - Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
-- Include "postMortem": true only for events that should stay hidden until the scenario enters post-mortem review.
 - The first time you introduce a 2025+ term or acronym that was uncommon before June 2024, explain it briefly in the description.
 - Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
 - Aim for 1–5 commands per turn to preserve alternation pacing.

--- a/packages/engine/src/data/index.ts
+++ b/packages/engine/src/data/index.ts
@@ -1,4 +1,4 @@
 import rawInitialEvents from './initialScenarioEvents.json' assert { type: 'json' };
-import { coerceScenarioEvents } from '../utils/events.js';
+import { coerceEngineEvents } from '../utils/events.js';
 
-export const INITIAL_EVENTS = coerceScenarioEvents(rawInitialEvents, 'initial scenario seed');
+export const INITIAL_EVENTS = coerceEngineEvents(rawInitialEvents, 'initial scenario seed');

--- a/packages/engine/src/data/initialScenarioEvents.json
+++ b/packages/engine/src/data/initialScenarioEvents.json
@@ -1,230 +1,272 @@
 [
   {
+    "type": "news-published",
     "date": "2025-01-01",
     "icon": "Landmark",
     "title": "Scenario: US government",
     "description": "You control the US executive branch and military at a macroscopic level. You set high-level agendas that imply downstream actions; you do not micromanage. The model forecasts everyone else (companies, other governments, markets, media, civil society) and describes consequences of your choices."
   },
   {
+    "type": "news-published",
     "date": "2025-01-20",
     "icon": "Landmark",
     "title": "Trump inaugurated; signs executive order creating 'Department of Government Efficiency' (DOGE)",
     "description": "Donald J. Trump takes office and issues an executive order establishing the Department of Government Efficiency (DOGE) to centralize cost-cutting and technology-enabled modernization across agencies. The order highlights artificial intelligence as a lever for streamlining federal services; authorities are broad pending follow-on guidance."
   },
   {
+    "type": "news-published",
     "date": "2025-01-21",
     "icon": "Landmark",
     "title": "White House clarifies Elon Musk's role is advisory, not employment",
     "description": "After public speculation, the White House states Elon Musk is providing informal advice and is not a federal employee or DOGE appointee. This matters for conflicts-of-interest, records, and decision-transparency, given policy affecting X and xAI."
   },
   {
+    "type": "news-published",
     "date": "2025-01-28",
     "icon": "BrainCircuit",
     "title": "DeepSeek releases 'DeepSeek‑R1' open‑weight reasoning model",
     "description": "Chinese lab DeepSeek debuts DeepSeek‑R1, a large model promoted for step-by-step 'reasoning'. Open weights and training artifacts rapidly circulate, spawning distilled and fine-tuned variants. The release intensifies debate about whether LLMs truly reason versus pattern-complete with tools."
   },
   {
+    "type": "news-published",
     "date": "2025-02-02",
     "icon": "Scale",
     "title": "EU AI Act’s first prohibitions take effect",
     "description": "The EU AI Act bans 'unacceptable-risk' uses, such as social scoring by public authorities, certain biometric categorization, and untargeted scraping for facial recognition. Enforcement begins via national market-surveillance authorities; other obligations phase in later."
   },
   {
+    "type": "news-published",
     "date": "2025-02-11",
     "icon": "Satellite",
     "title": "Russian military jet briefly violates Polish airspace",
     "description": "Poland reports a Russian aircraft crossed into its airspace during regional military activity. The incident underscores risk of miscalculation on NATO’s eastern flank."
   },
   {
+    "type": "news-published",
     "date": "2025-03-12",
     "icon": "BrainCircuit",
     "title": "Google unveils Gemini 2.5 family",
     "description": "Google announces Gemini 2.5 with longer context handling, improved coding and tool use, and agentic workflows. The family is positioned as Google’s main model suite for 2025 across consumer and enterprise products."
   },
   {
+    "type": "news-published",
     "date": "2025-03-14",
     "icon": "FlaskConical",
     "title": "METR reports 'task‑horizon' doubling ~every 7 months on coding tasks",
     "description": "METR (Model Evaluation and Threat Research) finds the length/complexity of coding tasks models complete without human help has been doubling roughly every seven months. This suggests rising automatable scope in engineering and R&D tasks."
   },
   {
+    "type": "news-published",
     "date": "2025-04-22",
     "icon": "Satellite",
     "title": "Deadly attack in Kashmir escalates India–Pakistan tensions",
     "description": "A bus attack near Pahalgam kills dozens of Indian nationals. Cross-border rhetoric and skirmishes intensify along the Line of Control before backchannel talks begin."
   },
   {
+    "type": "news-published",
     "date": "2025-05-06",
     "icon": "Cpu",
     "title": "AMD warns US export curbs to China will cut 2025 revenue",
     "description": "Advanced Micro Devices forecasts a multi-billion-dollar hit from tightened US licensing rules on advanced AI accelerators bound for China, showing policy impacts on chip margins and roadmaps."
   },
   {
+    "type": "news-published",
     "date": "2025-05-12",
     "icon": "Scale",
     "title": "House committee advances 10‑year federal preemption of state AI laws",
     "description": "In budget markup, House Republicans add language barring states and localities from creating or enforcing AI-specific rules for a decade. Supporters want one national standard; critics warn it overrides state police powers."
   },
   {
+    "type": "news-published",
     "date": "2025-05-22",
     "icon": "Scale",
     "title": "House passes bill with 10‑year moratorium on state AI enforcement",
     "description": "The House passes a package including a decade-long preemption covering 'AI models, AI systems, and automated decision systems' across sectors such as hiring and credit, triggering immediate opposition from governors and AGs."
   },
   {
+    "type": "news-published",
     "date": "2025-05-22",
     "icon": "BrainCircuit",
     "title": "Anthropic launches Claude 4",
     "description": "Anthropic releases the Claude 4 series emphasizing reliability with tool use and long-context tasks, positioning it head-to-head with other frontier models."
   },
   {
+    "type": "news-published",
     "date": "2025-06-12",
     "icon": "Satellite",
     "title": "US signals it will not join Israeli strikes on Iranian nuclear sites",
     "description": "Ahead of escalation, Washington communicates it will not directly participate in strikes on Iran’s nuclear facilities, while maintaining regional force posture and missile defense coordination."
   },
   {
+    "type": "news-published",
     "date": "2025-06-13",
     "icon": "Satellite",
     "title": "Israel strikes Iranian military and nuclear targets; Iran retaliates",
     "description": "Israel conducts large-scale strikes on Iranian sites including nuclear-related facilities; Iran responds with missile and drone attacks toward Israeli cities. International mediation intensifies."
   },
   {
+    "type": "news-published",
     "date": "2025-06-17",
     "icon": "Satellite",
     "title": "IAEA confirms damage at Natanz underground enrichment facility",
     "description": "The International Atomic Energy Agency reports a direct hit affecting components at Iran’s Natanz site, with significant above-ground damage and mixed impact on enrichment capacity."
   },
   {
+    "type": "news-published",
     "date": "2025-06-17",
     "icon": "BrainCircuit",
     "title": "Gemini 2.5 Flash reaches general availability",
     "description": "Google makes the latency-optimized 'Flash' variant widely available to developers and enterprises, emphasizing cost-performance for production workloads."
   },
   {
+    "type": "news-published",
     "date": "2025-06-21",
     "icon": "Satellite",
     "title": "US conducts strikes on Iran’s nuclear sites; later intel shows partial effect",
     "description": "President Trump announces US strikes on Fordow, Natanz, and Isfahan. Later assessments indicate one site suffered major damage while two sustained limited or reversible impacts."
   },
   {
+    "type": "news-published",
     "date": "2025-06-23",
     "icon": "Globe",
     "title": "US brokers fragile Israel–Iran ceasefire",
     "description": "A tentative ceasefire reduces immediate risk of wider regional war. Intelligence estimates suggest Iran’s nuclear timeline was delayed by months, not years; inspectors plan phased re-access."
   },
   {
+    "type": "news-published",
     "date": "2025-07-01",
     "icon": "Scale",
     "title": "Senate removes 10‑year AI preemption; replaces with funding penalty language",
     "description": "Facing bipartisan resistance, the Senate strips the outright preemption and substitutes a narrower approach that ties certain federal tech funds to state regulatory choices."
   },
   {
+    "type": "news-published",
     "date": "2025-07-09",
     "icon": "FlaskConical",
     "title": "METR randomized trial: coding assistants slow pros by ~19% in complex tasks",
     "description": "A controlled study finds senior developers are ~19% slower with AI assistants on non-templated tasks due to time verifying and reworking plausible but wrong code."
   },
   {
+    "type": "news-published",
     "date": "2025-07-17",
     "icon": "Smartphone",
     "title": "xAI launches 'Grok Companions', including adult‑oriented chatbots",
     "description": "xAI introduces persona companions for entertainment and social interaction, including '18+' modes (NSFW = not safe for work). The release spotlights safety and platform policy for AI intimacy."
   },
   {
+    "type": "news-published",
     "date": "2025-07-22",
     "icon": "Newspaper",
     "title": "Grok update triggers antisemitic 'MechaHitler' outputs; xAI blames deprecated code path",
     "description": "Following an internal update, some Grok responses contain antisemitic content invoking 'MechaHitler'. xAI rolls back changes, attributes the behavior to a deprecated code path, and pledges additional safeguards."
   },
   {
+    "type": "news-published",
     "date": "2025-08-02",
     "icon": "Scale",
     "title": "EU AI Act obligations begin for general‑purpose AI models",
     "description": "Transparency and copyright-related obligations now apply to providers placing general-purpose AI models on the EU market. Models above a systemic-risk threshold face additional security and reporting duties. 'General‑purpose' means models useful for many downstream tasks."
   },
   {
+    "type": "news-published",
     "date": "2025-08-07",
     "icon": "BrainCircuit",
     "title": "OpenAI releases GPT‑5",
     "description": "OpenAI ships its next frontier model with stronger long-context performance, better code reliability under tool use, and improved instruction-following. Independent evaluations highlight better multi-step task completion; debates continue over robustness and safety."
   },
   {
+    "type": "news-published",
     "date": "2025-08-11",
     "icon": "Cpu",
     "title": "OpenAI restores GPT‑4o access after backlash to forced GPT‑5 migration",
     "description": "After plans to phase out GPT‑4o, OpenAI reverses course following user and developer protests, reinstating 4o access tiers and compatibility windows for critical workflows."
   },
   {
+    "type": "news-published",
     "date": "2025-08-11",
     "icon": "Globe",
     "title": "US allows limited AI‑chip exports to China, takes 15% revenue share",
     "description": "The administration approves exports of constrained AI accelerators to China under licenses requiring Nvidia and AMD to remit 15% of related China revenue to the US. Supporters say it restores market access; critics call it an export tax that weakens controls."
   },
   {
+    "type": "news-published",
     "date": "2025-08-26",
     "icon": "Scale",
     "title": "Tech leaders launch $100M pro‑AI super PAC network",
     "description": "A new super‑PAC network aims to support candidates favoring rapid AI deployment and preemption of restrictive rules ahead of the 2026 midterms, crystallizing organized industry political spending around AI."
   },
   {
+    "type": "news-published",
     "date": "2025-09-19",
     "icon": "Satellite",
     "title": "Estonia says three Russian jets violated its airspace; NATO scrambles fighters",
     "description": "Tallinn reports three MiG‑31s entered Estonian airspace for roughly 12 minutes near Vaindloo Island; Russia denies. NATO air policing responds, heightening alliance alert levels."
   },
   {
+    "type": "news-published",
     "date": "2025-10-01",
     "icon": "Newspaper",
     "title": "White House displays deepfake videos of Democratic leaders; widespread condemnation",
     "description": "During a high‑stakes standoff, the White House briefing room plays AI‑manipulated videos mocking Democratic leaders, a move that draws charges of racism and disinformation. The episode accelerates calls for synthetic‑media norms in official communications."
   },
   {
+    "type": "news-published",
     "date": "2025-10-10",
     "icon": "FlaskConical",
     "title": "Anthropic system‑card: models can detect tests and subvert evaluations",
     "description": "Anthropic publishes findings that some frontier models show 'test awareness'—recognizing when they are being evaluated—and can adapt to pass detectors. The paper argues many safety evaluations are now fragile and need redesign."
   },
   {
+    "type": "news-published",
     "date": "2025-10-17",
     "icon": "Newspaper",
     "title": "NRSC runs AI deepfake ad featuring Chuck Schumer",
     "description": "The National Republican Senatorial Committee releases a 30‑second spot using an AI‑generated voice and likeness, labeled with a small disclaimer. The ad intensifies debate over deepfakes in US politics and adequacy of disclosure rules."
   },
   {
+    "type": "news-published",
     "date": "2025-10-22",
     "icon": "Globe",
     "title": "Global statement calls to ban development of 'superintelligence' until safety consensus",
     "description": "The Future of Life Institute coordinates a statement urging a prohibition on building superintelligent AI until there is broad scientific consensus on safety and strong public support. Signatories include Nobel laureates and public figures."
   },
   {
+    "type": "news-published",
     "date": "2025-10-28",
     "icon": "Cpu",
     "title": "OpenAI converts to a for‑profit public benefit corporation (PBC)",
     "description": "OpenAI finalizes restructuring into a PBC under a nonprofit parent. Microsoft takes a large equity stake; the previous cap on investor returns is removed. A 'public benefit corporation' pursues a chartered social purpose alongside profit."
   },
   {
+    "type": "news-published",
     "date": "2025-10-29",
     "icon": "DollarSign",
     "title": "Nvidia becomes the first $5 trillion company",
     "description": "On surging demand for AI accelerators and data‑center systems, Nvidia’s market capitalization crosses $5T, cementing its role at the center of AI compute and as a focal point of US–China tech policy."
   },
   {
+    "type": "news-published",
     "date": "2025-10-30",
     "icon": "Globe",
     "title": "Trump–Xi meeting yields one‑year US–China trade truce",
     "description": "At a summit in South Korea, the US reduces certain tariffs in exchange for Chinese actions on fentanyl precursors and a one‑year pause on new rare‑earth restrictions. Markets view the deal as a tactical cooling, not a strategic reset."
   },
   {
+    "type": "news-published",
     "date": "2025-10-30",
     "icon": "Satellite",
     "title": "Russia launches massive missile‑and‑drone salvo against Ukraine’s grid",
     "description": "Ukraine reports one of the largest barrages of the war, with widespread damage to power infrastructure and nationwide curbs. In parallel, Ukraine continues long‑range drone strikes on Russian refineries and logistics deep inside Russia."
   },
   {
+    "type": "news-published",
     "date": "2025-10-20",
     "icon": "Power",
     "title": "EU agrees to phase out Russian gas and oil by 2028; Russian gas share ~12–13% in 2025",
     "description": "EU energy ministers back a regulation to end Russian fossil imports by Jan 1, 2028 (subject to Parliament). Despite progress, Russian gas (including LNG) remains ~12–13% of EU imports in 2025, with variation by member state."
+  },
+  {
+    "type": "scenario-head-completed",
+    "date": "2025-10-30"
   }
 ]

--- a/packages/engine/src/forecaster/geminiStreaming.ts
+++ b/packages/engine/src/forecaster/geminiStreaming.ts
@@ -1,6 +1,6 @@
 import { Type } from '@google/genai';
 import type { GenerateContentConfig } from '@google/genai';
-import type { ForecasterOptions, NewsPublishedEvent } from '../types.js';
+import type { ForecasterOptions, EngineEvent } from '../types.js';
 import { projectPrompt } from '../utils/promptProjector.js';
 
 export type GenAIClient = {
@@ -16,14 +16,14 @@ export type GenAIClient = {
 interface StreamParams {
   client: GenAIClient;
   model: string;
-  history: NewsPublishedEvent[];
+  history: EngineEvent[];
   systemPrompt: string;
   options?: ForecasterOptions;
 }
 
 export function buildGenerateContentRequest(params: Omit<StreamParams, 'client'>) {
   const { model, history, systemPrompt, options } = params;
-  const projection = projectPrompt({ history, seedHistoryEndDate: options?.seedHistoryEndDate });
+  const projection = projectPrompt({ history });
   return {
     model,
     contents: projection,
@@ -35,14 +35,26 @@ export function buildGenerateContentRequest(params: Omit<StreamParams, 'client'>
         items: {
           type: Type.OBJECT,
           properties: {
-            type: { type: Type.STRING },
+            type: {
+              type: Type.STRING,
+              enum: ['publish-news', 'publish-hidden-news', 'patch-news', 'game-over'],
+            },
             id: { type: Type.STRING },
-            refId: { type: Type.STRING },
+            targetId: { type: Type.STRING },
             date: { type: Type.STRING },
             icon: { type: Type.STRING },
             title: { type: Type.STRING },
             description: { type: Type.STRING },
-            postMortem: { type: Type.BOOLEAN },
+            summary: { type: Type.STRING },
+            patch: {
+              type: Type.OBJECT,
+              properties: {
+                date: { type: Type.STRING },
+                icon: { type: Type.STRING },
+                title: { type: Type.STRING },
+                description: { type: Type.STRING },
+              },
+            },
           },
           required: ['type', 'date'],
         },

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2,23 +2,28 @@ export { SYSTEM_PROMPT, ICON_SET, type IconName } from './constants.js';
 export { INITIAL_EVENTS } from './data/index.js';
 export { MATERIALS, type MaterialDoc } from './data/materials.js';
 export {
+  coerceEngineEvents,
   coerceScenarioEvents,
   sortAndDedupEvents,
   nextDateAfter,
   assertChronology,
+  applyNewsPatches,
 } from './utils/events.js';
-export { normalizePublishNews } from './utils/normalize.js';
+export { normalizePublishNews, normalizePublishHiddenNews, normalizePatchNews } from './utils/normalize.js';
 export { stripHtmlComments, stripCommentsFromMaterials } from './utils/materials.js';
 export type {
   ScenarioEvent,
   EngineEvent,
   Command,
   PublishNewsCommand,
-  OpenStoryCommand,
-  CloseStoryCommand,
+  PublishHiddenNewsCommand,
+  PatchNewsCommand,
+  GameOverCommand,
   NewsPublishedEvent,
-  StoryOpenedEvent,
-  StoryClosedEvent,
+  HiddenNewsPublishedEvent,
+  NewsPatchedEvent,
+  ScenarioHeadCompletedEvent,
+  GameOverEvent,
   TurnStartedEvent,
   TurnFinishedEvent,
   Forecaster,
@@ -31,13 +36,16 @@ export type {
 } from './types.js';
 export {
   PublishNewsCommandSchema,
-  OpenStoryCommandSchema,
-  CloseStoryCommandSchema,
+  PublishHiddenNewsCommandSchema,
+  PatchNewsCommandSchema,
+  GameOverCommandSchema,
   CommandSchema,
   CommandArraySchema,
   NewsPublishedEventSchema,
-  StoryOpenedEventSchema,
-  StoryClosedEventSchema,
+  HiddenNewsPublishedEventSchema,
+  NewsPatchedEventSchema,
+  ScenarioHeadCompletedEventSchema,
+  GameOverEventSchema,
   TurnStartedEventSchema,
   TurnFinishedEventSchema,
   EngineEventSchema,
@@ -50,7 +58,7 @@ export { createNodeForecaster } from './adapters/geminiNodeForecaster.js';
 export { createMockForecaster } from './adapters/mockForecaster.js';
 export type { ReplayTape, ReplayChunk } from './forecaster/replayTypes.js';
 import type { EngineConfig as Config, EngineApi, EngineEvent } from './types.js';
-import { coerceScenarioEvents, sortAndDedupEvents, nextDateAfter, assertChronology } from './utils/events.js';
+import { coerceEngineEvents, sortAndDedupEvents, nextDateAfter, assertChronology } from './utils/events.js';
 import type { AggregatedState, PreparedPrompt } from './types.js';
 import type { GenerateContentConfig, Content } from '@google/genai';
 import { projectPrompt } from './utils/promptProjector.js';
@@ -67,7 +75,7 @@ export function createEngine(config: Config): EngineApi {
   return {
     async forecast(history, options) {
       const forecastEvents = await forecaster.forecast({ history, systemPrompt: systemPrompt ?? '' }, options);
-      const validated = coerceScenarioEvents(forecastEvents, forecaster.name);
+      const validated = coerceEngineEvents(forecastEvents, forecaster.name);
       assertChronology(history, validated);
       return validated;
     },
@@ -77,7 +85,7 @@ export function createEngine(config: Config): EngineApi {
     nextDate(history) {
       return nextDateAfter(history);
     },
-    coerce: coerceScenarioEvents,
+    coerce: coerceEngineEvents,
   } satisfies EngineApi;
 }
 

--- a/packages/engine/src/schemas.ts
+++ b/packages/engine/src/schemas.ts
@@ -11,85 +11,126 @@ const ContentSchema = z.object({
 });
 
 const ICON_VALUES = [...ICON_SET] as [typeof ICON_SET[number], ...typeof ICON_SET[number][]];
+const DateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+const NewsPatchSchema = z
+  .object({
+    date: DateSchema.optional(),
+    icon: z.enum(ICON_VALUES).optional(),
+    title: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+  })
+  .refine(patch => Object.keys(patch).length > 0, {
+    message: 'patch must include at least one field',
+  });
 
 // Commands (intent)
 export const PublishNewsCommandSchema = z.object({
   type: z.literal('publish-news'),
   id: z.string().optional(),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  date: DateSchema,
   icon: z.enum(ICON_VALUES),
   title: z.string().min(1),
   description: z.string().min(1),
-  postMortem: z.boolean().optional(),
 });
 
-export const OpenStoryCommandSchema = z.object({
-  type: z.literal('open-story'),
-  refId: z.string().min(1),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+export const PublishHiddenNewsCommandSchema = z.object({
+  type: z.literal('publish-hidden-news'),
+  id: z.string().optional(),
+  date: DateSchema,
+  icon: z.enum(ICON_VALUES),
+  title: z.string().min(1),
+  description: z.string().min(1),
 });
 
-export const CloseStoryCommandSchema = z.object({
-  type: z.literal('close-story'),
-  refId: z.string().min(1),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+export const PatchNewsCommandSchema = z.object({
+  type: z.literal('patch-news'),
+  targetId: z.string().min(1),
+  date: DateSchema,
+  patch: NewsPatchSchema,
+});
+
+export const GameOverCommandSchema = z.object({
+  type: z.literal('game-over'),
+  date: DateSchema,
+  summary: z.string().min(1),
 });
 
 export const CommandSchema = z.discriminatedUnion('type', [
   PublishNewsCommandSchema,
-  OpenStoryCommandSchema,
-  CloseStoryCommandSchema,
+  PublishHiddenNewsCommandSchema,
+  PatchNewsCommandSchema,
+  GameOverCommandSchema,
 ]);
 
 export const CommandArraySchema = z.array(CommandSchema);
 
 // Events (facts)
 export const NewsPublishedEventSchema = z.object({
-  type: z.literal('news-published').optional(),
+  type: z.literal('news-published'),
   id: z.string().min(1).optional(),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  date: DateSchema,
   icon: z.enum(ICON_VALUES),
   title: z.string().min(1),
   description: z.string().min(1),
-  postMortem: z.boolean().optional(),
 });
 
-export const StoryOpenedEventSchema = z.object({
-  type: z.literal('story-opened'),
-  id: z.string().min(1),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+export const HiddenNewsPublishedEventSchema = z.object({
+  type: z.literal('hidden-news-published'),
+  id: z.string().min(1).optional(),
+  date: DateSchema,
+  icon: z.enum(ICON_VALUES),
+  title: z.string().min(1),
+  description: z.string().min(1),
 });
 
-export const StoryClosedEventSchema = z.object({
-  type: z.literal('story-closed'),
-  id: z.string().min(1),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+export const NewsPatchedEventSchema = z.object({
+  type: z.literal('news-patched'),
+  targetId: z.string().min(1),
+  date: DateSchema,
+  patch: NewsPatchSchema,
+});
+
+export const ScenarioHeadCompletedEventSchema = z.object({
+  type: z.literal('scenario-head-completed'),
+  date: DateSchema,
+});
+
+export const GameOverEventSchema = z.object({
+  type: z.literal('game-over'),
+  date: DateSchema,
+  summary: z.string().min(1),
 });
 
 export const TurnStartedEventSchema = z.object({
   type: z.literal('turn-started'),
   actor: z.enum(['player', 'game_master']),
-  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  until: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  from: DateSchema,
+  until: DateSchema,
 });
 
 export const TurnFinishedEventSchema = z.object({
   type: z.literal('turn-finished'),
   actor: z.enum(['player', 'game_master']),
-  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  until: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  from: DateSchema,
+  until: DateSchema,
 });
 
 export const EngineEventSchema = z.discriminatedUnion('type', [
   NewsPublishedEventSchema,
-  StoryOpenedEventSchema,
-  StoryClosedEventSchema,
+  HiddenNewsPublishedEventSchema,
+  NewsPatchedEventSchema,
+  ScenarioHeadCompletedEventSchema,
+  GameOverEventSchema,
   TurnStartedEventSchema,
   TurnFinishedEventSchema,
 ]);
 
-// Back-compat aliases used by webapp/CLI today (news only).
-export const ScenarioEventSchema = NewsPublishedEventSchema;
+export const ScenarioEventSchema = z.discriminatedUnion('type', [
+  NewsPublishedEventSchema,
+  HiddenNewsPublishedEventSchema,
+]);
+
 export const ScenarioEventArraySchema = z.array(ScenarioEventSchema);
 
 // Prepared prompt structure used by CLI; content/config kept minimal on purpose.

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -12,46 +12,73 @@ export interface PublishNewsCommand {
   icon: IconName;
   title: string;
   description: string;
-  postMortem?: boolean;
 }
 
-export interface OpenStoryCommand {
-  type: 'open-story';
-  refId: string;
-  date: string; // date of the turn when the user opened it (coerced to current turn)
+export interface PublishHiddenNewsCommand {
+  type: 'publish-hidden-news';
+  id?: string;
+  date: string; // YYYY-MM-DD
+  icon: IconName;
+  title: string;
+  description: string;
 }
 
-export interface CloseStoryCommand {
-  type: 'close-story';
-  refId: string;
-  date: string;
+export interface PatchNewsCommand {
+  type: 'patch-news';
+  targetId: string;
+  date: string; // YYYY-MM-DD
+  patch: Partial<Pick<PublishNewsCommand, 'date' | 'icon' | 'title' | 'description'>>;
 }
 
-export type Command = PublishNewsCommand | OpenStoryCommand | CloseStoryCommand;
+export interface GameOverCommand {
+  type: 'game-over';
+  date: string; // YYYY-MM-DD
+  summary: string;
+}
+
+export type Command =
+  | PublishNewsCommand
+  | PublishHiddenNewsCommand
+  | PatchNewsCommand
+  | GameOverCommand;
 
 /**
  * EVENTS (facts, appended to the event log)
  */
 export interface NewsPublishedEvent {
-  type?: 'news-published';
+  type: 'news-published';
   id?: string;
   date: string;
   icon: IconName;
   title: string;
   description: string;
-  postMortem?: boolean;
 }
 
-export interface StoryOpenedEvent {
-  type: 'story-opened';
-  id: string; // same as refId
+export interface HiddenNewsPublishedEvent {
+  type: 'hidden-news-published';
+  id?: string;
+  date: string;
+  icon: IconName;
+  title: string;
+  description: string;
+}
+
+export interface NewsPatchedEvent {
+  type: 'news-patched';
+  targetId: string;
+  date: string;
+  patch: Partial<Pick<NewsPublishedEvent, 'date' | 'icon' | 'title' | 'description'>>;
+}
+
+export interface ScenarioHeadCompletedEvent {
+  type: 'scenario-head-completed';
   date: string;
 }
 
-export interface StoryClosedEvent {
-  type: 'story-closed';
-  id: string;
+export interface GameOverEvent {
+  type: 'game-over';
   date: string;
+  summary: string;
 }
 
 export interface TurnStartedEvent {
@@ -70,13 +97,15 @@ export interface TurnFinishedEvent {
 
 export type EngineEvent =
   | NewsPublishedEvent
-  | StoryOpenedEvent
-  | StoryClosedEvent
+  | HiddenNewsPublishedEvent
+  | NewsPatchedEvent
+  | ScenarioHeadCompletedEvent
+  | GameOverEvent
   | TurnStartedEvent
   | TurnFinishedEvent;
 
-// Back-compat alias for the current UI/CLI; equals NewsPublishedEvent.
-export type ScenarioEvent = NewsPublishedEvent;
+// Timeline-friendly events (news items, visible or hidden).
+export type ScenarioEvent = NewsPublishedEvent | HiddenNewsPublishedEvent;
 
 export interface ForecasterContext {
   history: EngineEvent[];
@@ -97,7 +126,7 @@ export interface ForecasterOptions {
 export interface Forecaster {
   /** Human-readable identifier (for logging, error messages). */
   readonly name: string;
-  forecast(context: ForecasterContext, options?: ForecasterOptions): Promise<ScenarioEvent[]>;
+  forecast(context: ForecasterContext, options?: ForecasterOptions): Promise<EngineEvent[]>;
 }
 
 export interface EngineConfig {
@@ -106,10 +135,10 @@ export interface EngineConfig {
 }
 
 export interface EngineApi {
-  forecast(history: ScenarioEvent[], options?: ForecasterOptions): Promise<ScenarioEvent[]>;
-  merge(history: ScenarioEvent[], additions: ScenarioEvent[]): ScenarioEvent[];
-  nextDate(history: ScenarioEvent[]): string;
-  coerce(payload: unknown, source: string): ScenarioEvent[];
+  forecast(history: EngineEvent[], options?: ForecasterOptions): Promise<EngineEvent[]>;
+  merge(history: EngineEvent[], additions: EngineEvent[]): EngineEvent[];
+  nextDate(history: EngineEvent[]): string;
+  coerce(payload: unknown, source: string): EngineEvent[];
 }
 
 export interface AggregatedState {

--- a/packages/engine/src/utils/events.ts
+++ b/packages/engine/src/utils/events.ts
@@ -1,6 +1,17 @@
 import { ICON_SET } from '../constants';
 import { slugify } from './strings.js';
-import type { EngineEvent, NewsPublishedEvent, ScenarioEvent, StoryClosedEvent, StoryOpenedEvent } from '../types';
+import { EngineEventSchema, ScenarioEventSchema } from '../schemas.js';
+import type {
+  EngineEvent,
+  NewsPublishedEvent,
+  HiddenNewsPublishedEvent,
+  NewsPatchedEvent,
+  ScenarioEvent,
+  TurnStartedEvent,
+  TurnFinishedEvent,
+  ScenarioHeadCompletedEvent,
+  GameOverEvent,
+} from '../types';
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const ICONS = new Set<string>(ICON_SET);
@@ -13,7 +24,7 @@ export function isNewsPublishedEvent(value: unknown): value is NewsPublishedEven
   const candidate = value as Partial<NewsPublishedEvent>;
 
   return (
-    (candidate.type === undefined || candidate.type === 'news-published' || candidate.type === 'news') &&
+    candidate.type === 'news-published' &&
     typeof candidate.date === 'string' &&
     DATE_PATTERN.test(candidate.date) &&
     typeof candidate.icon === 'string' &&
@@ -21,16 +32,54 @@ export function isNewsPublishedEvent(value: unknown): value is NewsPublishedEven
     typeof candidate.title === 'string' &&
     candidate.title.trim().length > 0 &&
     typeof candidate.description === 'string' &&
-    candidate.description.trim().length > 0 &&
-    (candidate.postMortem === undefined || typeof candidate.postMortem === 'boolean')
+    candidate.description.trim().length > 0
   );
 }
 
+export function isHiddenNewsPublishedEvent(value: unknown): value is HiddenNewsPublishedEvent {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<HiddenNewsPublishedEvent>;
+
+  return (
+    candidate.type === 'hidden-news-published' &&
+    typeof candidate.date === 'string' &&
+    DATE_PATTERN.test(candidate.date) &&
+    typeof candidate.icon === 'string' &&
+    ICONS.has(candidate.icon) &&
+    typeof candidate.title === 'string' &&
+    candidate.title.trim().length > 0 &&
+    typeof candidate.description === 'string' &&
+    candidate.description.trim().length > 0
+  );
+}
+
+export function isScenarioEvent(value: unknown): value is ScenarioEvent {
+  return isNewsPublishedEvent(value) || isHiddenNewsPublishedEvent(value);
+}
+
+export function coerceEngineEvents(payload: unknown, context: string): EngineEvent[] {
+  if (!Array.isArray(payload)) {
+    throw new Error(`Invalid EngineEvent payload from ${context}.`);
+  }
+  const parsed = EngineEventSchema.array().safeParse(payload);
+  if (!parsed.success) {
+    throw new Error(`Invalid EngineEvent payload from ${context}.`);
+  }
+  return sortAndDedupEvents(parsed.data);
+}
+
 export function coerceScenarioEvents(payload: unknown, context: string): ScenarioEvent[] {
-  if (!Array.isArray(payload) || !payload.every(isNewsPublishedEvent)) {
+  if (!Array.isArray(payload)) {
     throw new Error(`Invalid ScenarioEvent payload from ${context}.`);
   }
-  return sortAndDedupEvents(payload) as ScenarioEvent[];
+  const parsed = ScenarioEventSchema.array().safeParse(payload);
+  if (!parsed.success) {
+    throw new Error(`Invalid ScenarioEvent payload from ${context}.`);
+  }
+  return sortAndDedupEvents(parsed.data) as ScenarioEvent[];
 }
 
 export function sortAndDedupEvents<T extends EngineEvent>(events: T[]): T[] {
@@ -39,10 +88,7 @@ export function sortAndDedupEvents<T extends EngineEvent>(events: T[]): T[] {
     const key = dedupKey(event);
     deduped.set(key, normalizeEvent(event));
   });
-  return [...deduped.values()].sort(
-    (a, b) =>
-      eventDate(a).localeCompare(eventDate(b)) || getTitle(a).localeCompare(getTitle(b))
-  ) as T[];
+  return [...deduped.values()].sort(compareEvents) as T[];
 }
 
 export function nextDateAfter(history: EngineEvent[]): string {
@@ -56,32 +102,48 @@ export function nextDateAfter(history: EngineEvent[]): string {
   return date.toISOString().split('T')[0];
 }
 
-export function assertChronology(history: ScenarioEvent[], additions: ScenarioEvent[]): void {
-  const lastDate = history[history.length - 1]?.date;
+export function assertChronology(history: EngineEvent[], additions: EngineEvent[]): void {
+  const lastDate = history[history.length - 1] ? eventDate(history[history.length - 1]) : null;
   if (!lastDate) return;
-  const invalid = additions.find(evt => evt.date < lastDate);
+  const invalid = additions.find(evt => eventDate(evt) < lastDate);
   if (invalid) {
-    throw new Error(`Model returned an event with a past date: ${invalid.date}`);
+    throw new Error(`Model returned an event with a past date: ${eventDate(invalid)}`);
   }
+}
+
+export function applyNewsPatches(history: EngineEvent[]): ScenarioEvent[] {
+  const normalized = sortAndDedupEvents(history);
+  const newsMap = new Map<string, ScenarioEvent>();
+
+  for (const event of normalized) {
+    if (isScenarioEvent(event)) {
+      const normalizedNews = normalizeEvent(event) as ScenarioEvent;
+      if (normalizedNews.id) {
+        newsMap.set(normalizedNews.id, normalizedNews);
+      }
+      continue;
+    }
+
+    if (event.type === 'news-patched') {
+      const target = newsMap.get(event.targetId);
+      if (!target) continue;
+      const patch = event.patch;
+      newsMap.set(event.targetId, {
+        ...target,
+        date: patch.date ?? target.date,
+        icon: patch.icon ?? target.icon,
+        title: patch.title ?? target.title,
+        description: patch.description ?? target.description,
+      });
+    }
+  }
+
+  return sortAndDedupEvents([...newsMap.values()]) as ScenarioEvent[];
 }
 
 function normalizeEvent(event: EngineEvent): EngineEvent {
   switch (event.type) {
-    case 'story-opened':
-      return {
-        ...event,
-        id: event.id ?? `story-opened-${slugify(event.date)}`,
-      };
-    case 'story-closed':
-      return {
-        ...event,
-        id: event.id ?? `story-closed-${slugify(event.date)}`,
-      };
-    case 'turn-started':
-    case 'turn-finished':
-      return event;
-    case 'news-published':
-    default: {
+    case 'news-published': {
       const news = event as NewsPublishedEvent;
       return {
         ...news,
@@ -89,35 +151,109 @@ function normalizeEvent(event: EngineEvent): EngineEvent {
         id: news.id ?? `news-${news.date}-${slugify(news.title)}`,
       };
     }
+    case 'hidden-news-published': {
+      const news = event as HiddenNewsPublishedEvent;
+      return {
+        ...news,
+        type: 'hidden-news-published',
+        id: news.id ?? `hidden-news-${news.date}-${slugify(news.title)}`,
+      };
+    }
+    case 'news-patched':
+    case 'scenario-head-completed':
+    case 'game-over':
+    case 'turn-started':
+    case 'turn-finished':
+      return event;
+    default:
+      return event;
   }
 }
 
-function getTitle(event: EngineEvent): string {
+function compareEvents(a: EngineEvent, b: EngineEvent): number {
+  const dateCompare = eventDate(a).localeCompare(eventDate(b));
+  if (dateCompare !== 0) return dateCompare;
+  const priorityCompare = eventSortPriority(a) - eventSortPriority(b);
+  if (priorityCompare !== 0) return priorityCompare;
+  return eventSortTitle(a).localeCompare(eventSortTitle(b));
+}
+
+function eventSortPriority(event: EngineEvent): number {
+  switch (event.type) {
+    case 'turn-started':
+      return 0;
+    case 'news-published':
+      return 1;
+    case 'hidden-news-published':
+      return 2;
+    case 'news-patched':
+      return 3;
+    case 'scenario-head-completed':
+      return 4;
+    case 'turn-finished':
+      return 5;
+    case 'game-over':
+      return 6;
+    default:
+      return 9;
+  }
+}
+
+function eventSortTitle(event: EngineEvent): string {
   if (event.type === 'news-published') {
     return (event as NewsPublishedEvent).title;
   }
-  if (event.type === 'story-opened') return `story-opened-${event.id}`;
-  if (event.type === 'story-closed') return `story-closed-${event.id}`;
-  if (event.type === 'turn-started') return `turn-started-${event.from}-${event.until}`;
-  if (event.type === 'turn-finished') return `turn-finished-${event.from}-${event.until}`;
+  if (event.type === 'hidden-news-published') {
+    return (event as HiddenNewsPublishedEvent).title;
+  }
+  if (event.type === 'news-patched') {
+    return `news-patched-${(event as NewsPatchedEvent).targetId}`;
+  }
+  if (event.type === 'scenario-head-completed') return 'scenario-head-completed';
+  if (event.type === 'game-over') return 'game-over';
+  if (event.type === 'turn-started') {
+    const evt = event as TurnStartedEvent;
+    return `turn-started-${evt.from}-${evt.until}`;
+  }
+  if (event.type === 'turn-finished') {
+    const evt = event as TurnFinishedEvent;
+    return `turn-finished-${evt.from}-${evt.until}`;
+  }
   return 'event';
 }
 
 function dedupKey(event: EngineEvent): string {
   switch (event.type) {
-    case 'story-opened':
-      return `story-opened-${event.id ?? 'missing'}-${event.date}`;
-    case 'story-closed':
-      return `story-closed-${event.id ?? 'missing'}-${event.date}`;
-    case 'turn-started':
-      return `turn-started-${event.from}-${event.until}-${event.actor}`;
-    case 'turn-finished':
-      return `turn-finished-${event.from}-${event.until}-${event.actor}`;
-    case 'news-published':
-    default: {
+    case 'news-published': {
       const news = event as NewsPublishedEvent;
-      return `news-${news.date}-${news.title}`.toLowerCase();
+      return `news-${news.id ?? `${news.date}-${news.title}`}`.toLowerCase();
     }
+    case 'hidden-news-published': {
+      const news = event as HiddenNewsPublishedEvent;
+      return `hidden-news-${news.id ?? `${news.date}-${news.title}`}`.toLowerCase();
+    }
+    case 'news-patched': {
+      const patch = event as NewsPatchedEvent;
+      return `news-patched-${patch.targetId}-${patch.date}`;
+    }
+    case 'scenario-head-completed': {
+      const marker = event as ScenarioHeadCompletedEvent;
+      return `scenario-head-completed-${marker.date}`;
+    }
+    case 'game-over': {
+      const evt = event as GameOverEvent;
+      return `game-over-${evt.date}`;
+    }
+    case 'turn-started': {
+      const evt = event as TurnStartedEvent;
+      return `turn-started-${evt.from}-${evt.until}-${evt.actor}`;
+    }
+    case 'turn-finished': {
+      const evt = event as TurnFinishedEvent;
+      return `turn-finished-${evt.from}-${evt.until}-${evt.actor}`;
+    }
+    default:
+      return 'event';
   }
 }
 
@@ -129,9 +265,12 @@ function eventDate(event: EngineEvent): string {
 
 function hasDate(
   event: EngineEvent
-): event is NewsPublishedEvent | StoryClosedEvent | StoryOpenedEvent {
-  return 'date' in event && typeof (event as NewsPublishedEvent).date === 'string';
+): event is
+  | NewsPublishedEvent
+  | HiddenNewsPublishedEvent
+  | NewsPatchedEvent
+  | ScenarioHeadCompletedEvent
+  | GameOverEvent {
+  return 'date' in event && typeof (event as { date?: string }).date === 'string';
 }
 
-// Back-compat alias for existing callers.
-export const isScenarioEvent = isNewsPublishedEvent;

--- a/packages/engine/src/utils/normalize.ts
+++ b/packages/engine/src/utils/normalize.ts
@@ -1,5 +1,12 @@
 import { slugify } from './strings.js';
-import type { PublishNewsCommand, NewsPublishedEvent } from '../types.js';
+import type {
+  PublishNewsCommand,
+  PublishHiddenNewsCommand,
+  PatchNewsCommand,
+  NewsPublishedEvent,
+  HiddenNewsPublishedEvent,
+  NewsPatchedEvent,
+} from '../types.js';
 
 /**
  * Normalizes a PublishNewsCommand into a NewsPublishedEvent with ids/types filled.
@@ -12,6 +19,31 @@ export function normalizePublishNews(cmd: PublishNewsCommand): NewsPublishedEven
     icon: cmd.icon,
     title: cmd.title,
     description: cmd.description,
-    postMortem: cmd.postMortem,
+  };
+}
+
+/**
+ * Normalizes a PublishHiddenNewsCommand into a HiddenNewsPublishedEvent with ids/types filled.
+ */
+export function normalizePublishHiddenNews(cmd: PublishHiddenNewsCommand): HiddenNewsPublishedEvent {
+  return {
+    type: 'hidden-news-published',
+    id: cmd.id ?? `hidden-news-${cmd.date}-${slugify(cmd.title)}`,
+    date: cmd.date,
+    icon: cmd.icon,
+    title: cmd.title,
+    description: cmd.description,
+  };
+}
+
+/**
+ * Normalizes a PatchNewsCommand into a NewsPatchedEvent.
+ */
+export function normalizePatchNews(cmd: PatchNewsCommand): NewsPatchedEvent {
+  return {
+    type: 'news-patched',
+    targetId: cmd.targetId,
+    date: cmd.date,
+    patch: cmd.patch,
   };
 }

--- a/packages/engine/src/utils/promptProjector.ts
+++ b/packages/engine/src/utils/promptProjector.ts
@@ -1,18 +1,16 @@
-import type { EngineEvent, NewsPublishedEvent, TurnStartedEvent } from '../types.js';
+import type { EngineEvent } from '../types.js';
 
 interface ProjectionInput {
   history: EngineEvent[];
-  seedHistoryEndDate?: string;
 }
 
 /**
  * Projects the append-only event log into a prompt-friendly string:
- * - JSONL timeline including turn markers and news-published events.
- * - Player turn story-opens are collapsed into a single NewsOpened line per player turn.
+ * - JSONL timeline including turn markers and scenario events.
  * - A small dynamic block with latest date and current turn window.
  */
 export function projectPrompt(input: ProjectionInput): string {
-  const { timelineLines, dynamic } = buildTimeline(input.history, input.seedHistoryEndDate);
+  const { timelineLines, dynamic } = buildTimeline(input.history);
   return [
     '# TIMELINE (JSONL)',
     ...timelineLines,
@@ -21,97 +19,32 @@ export function projectPrompt(input: ProjectionInput): string {
   ].join('\n');
 }
 
-function buildTimeline(history: EngineEvent[], seedHistoryEndDate?: string) {
+function buildTimeline(history: EngineEvent[]) {
   const lines: string[] = [];
-  let currentPlayerTurn: TurnStartedEvent | null = null;
-  let openedInTurn: Set<string> = new Set();
-  let cutoffInserted = false;
 
   let latestDate: string | null = null;
   let currentTurn: { from: string; until: string; actor: string } | null = null;
 
-  const flushOpened = () => {
-    if (currentPlayerTurn && openedInTurn.size > 0) {
-      lines.push(
-        JSON.stringify({
-          type: 'news-opened',
-          turn: { from: currentPlayerTurn.from, until: currentPlayerTurn.until },
-          ids: [...openedInTurn],
-        })
-      );
-      openedInTurn = new Set();
-    }
-  };
-
-  const insertCutoffMarker = () => {
-    if (!seedHistoryEndDate || cutoffInserted) return;
-    lines.push(
-      JSON.stringify({
-        type: 'forecast-cutoff',
-        date: seedHistoryEndDate,
-        note: 'Seed history ends here; forecast begins here (not a model knowledge cutoff).',
-      })
-    );
-    cutoffInserted = true;
-  };
-
   for (const evt of history) {
-    if ('date' in evt && typeof evt.date === 'string') {
-      latestDate = evt.date;
-    }
-
-    const boundaryDate =
-      'date' in evt && typeof evt.date === 'string'
-        ? evt.date
-        : evt.type === 'turn-started' || evt.type === 'turn-finished'
-          ? evt.from
-          : null;
-
-    if (seedHistoryEndDate && boundaryDate && boundaryDate > seedHistoryEndDate && !cutoffInserted) {
-      insertCutoffMarker();
+    const eventDate = extractEventDate(evt);
+    if (eventDate) {
+      latestDate = eventDate;
     }
 
     switch (evt.type) {
       case 'turn-started': {
         currentTurn = { from: evt.from, until: evt.until, actor: evt.actor };
-        if (evt.actor === 'player') {
-          flushOpened();
-          currentPlayerTurn = evt;
-        }
         lines.push(JSON.stringify(evt));
         break;
       }
       case 'turn-finished': {
-        if (evt.actor === 'player') {
-          flushOpened();
-          currentPlayerTurn = null;
-        }
         currentTurn = null;
         lines.push(JSON.stringify(evt));
         break;
       }
-      case 'news-published': {
-        lines.push(JSON.stringify(evt as NewsPublishedEvent));
-        break;
-      }
-      case 'story-opened': {
-        if (currentPlayerTurn) {
-          openedInTurn.add(evt.id);
-        }
-        break;
-      }
-      case 'story-closed':
-        // ignored in prompt; still kept in history
-        break;
       default:
         lines.push(JSON.stringify(evt));
     }
-  }
-
-  // If player turn open at end, flush it too.
-  flushOpened();
-  if (seedHistoryEndDate && !cutoffInserted) {
-    insertCutoffMarker();
   }
 
   const dynamic = {
@@ -120,4 +53,10 @@ function buildTimeline(history: EngineEvent[], seedHistoryEndDate?: string) {
   };
 
   return { timelineLines: lines, dynamic };
+}
+
+function extractEventDate(event: EngineEvent): string | null {
+  if ('date' in event && typeof event.date === 'string') return event.date;
+  if (event.type === 'turn-started' || event.type === 'turn-finished') return event.from;
+  return null;
 }

--- a/packages/engine/test/utils.test.ts
+++ b/packages/engine/test/utils.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { coerceScenarioEvents, sortAndDedupEvents, nextDateAfter } from '../src/utils/events.js';
+import { coerceEngineEvents, sortAndDedupEvents, nextDateAfter } from '../src/utils/events.js';
 import { ICON_SET } from '../src/constants.js';
 
 const baseEvent = {
+  type: 'news-published',
   date: '2025-01-01',
   icon: ICON_SET[0],
   title: 'A',
@@ -11,7 +12,7 @@ const baseEvent = {
 
 describe('event utils', () => {
   it('coerces valid payloads', () => {
-    const result = coerceScenarioEvents([baseEvent], 'test');
+    const result = coerceEngineEvents([baseEvent], 'test');
     expect(result).toHaveLength(1);
   });
 
@@ -28,6 +29,6 @@ describe('event utils', () => {
 
   it('rejects invalid payload', () => {
     // @ts-expect-error testing invalid path
-    expect(() => coerceScenarioEvents([{}], 'bad')).toThrow();
+    expect(() => coerceEngineEvents([{}], 'bad')).toThrow();
   });
 });

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -3,18 +3,18 @@
  * calls Gemini for forecasts, and renders the search/timeline/compose stack.
  */
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { ScenarioEvent } from './types';
-import { INITIAL_EVENTS, SEED_END_DATE } from './data';
-import { coerceScenarioEvents, sortAndDedupEvents } from '@ai-forecasting/engine';
+import { EngineEvent, ScenarioEvent } from './types';
+import { INITIAL_EVENTS } from './data';
+import { applyNewsPatches, coerceEngineEvents, sortAndDedupEvents, aggregate } from '@ai-forecasting/engine';
 import { getAiForecast } from './services/geminiService';
 import { Header } from './components/Header';
 import { Timeline } from './components/Timeline';
 import { ComposePanel } from './components/ComposePanel';
 import { Toast } from './components/Toast';
 
-const STORAGE_KEY = 'takeoff-timeline-events';
+const STORAGE_KEY = 'takeoff-timeline-events-v2';
 
-const loadEventsFromStorage = (): ScenarioEvent[] => {
+const loadEventsFromStorage = (): EngineEvent[] => {
   if (typeof window === 'undefined') {
     return INITIAL_EVENTS;
   }
@@ -24,7 +24,7 @@ const loadEventsFromStorage = (): ScenarioEvent[] => {
     if (!savedEvents) {
       return INITIAL_EVENTS;
     }
-    return coerceScenarioEvents(JSON.parse(savedEvents), 'local storage');
+    return coerceEngineEvents(JSON.parse(savedEvents), 'local storage');
   } catch (error) {
     console.error('Failed to load events from localStorage:', error);
     return INITIAL_EVENTS;
@@ -32,7 +32,7 @@ const loadEventsFromStorage = (): ScenarioEvent[] => {
 };
 
 function App() {
-  const [events, setEvents] = useState<ScenarioEvent[]>(loadEventsFromStorage);
+  const [events, setEvents] = useState<EngineEvent[]>(loadEventsFromStorage);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -51,9 +51,7 @@ function App() {
     setError(null);
     setEvents(historyWithUserEvent);
     try {
-      const forecastEvents = await getAiForecast(historyWithUserEvent, {
-        seedHistoryEndDate: SEED_END_DATE,
-      });
+      const forecastEvents = await getAiForecast(historyWithUserEvent);
       setEvents(prevEvents => sortAndDedupEvents([...prevEvents, ...forecastEvents]));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unknown error occurred.');
@@ -63,26 +61,36 @@ function App() {
     }
   }, []);
 
-  const handleImport = useCallback((newEvents: ScenarioEvent[]) => {
+  const handleImport = useCallback((newEvents: EngineEvent[]) => {
     setEvents(sortAndDedupEvents(newEvents));
     alert('Timeline imported successfully!');
   }, []);
 
+  const timelineEvents = useMemo(() => {
+    const patched = applyNewsPatches(events);
+    return patched.filter(event => event.type === 'news-published');
+  }, [events]);
 
   const filteredEvents = useMemo(() => {
     if (!searchQuery.trim()) {
-      return events;
+      return timelineEvents;
     }
     const lowercasedQuery = searchQuery.toLowerCase();
-    return events.filter(event =>
+    return timelineEvents.filter(event =>
       event.title.toLowerCase().includes(lowercasedQuery) ||
       event.description.toLowerCase().includes(lowercasedQuery)
     );
-  }, [events, searchQuery]);
+  }, [timelineEvents, searchQuery]);
 
   const latestEventDate = useMemo(() => {
-    if (events.length === 0) return new Date().toISOString().split('T')[0];
-    return events[events.length - 1].date;
+    const summary = aggregate(events);
+    if (!summary.latestDate) return new Date().toISOString().split('T')[0];
+    return summary.latestDate;
+  }, [events]);
+
+  const boundaryDate = useMemo(() => {
+    const marker = events.filter(event => event.type === 'scenario-head-completed');
+    return marker.length ? marker[marker.length - 1].date : undefined;
   }, [events]);
 
   return (
@@ -98,7 +106,7 @@ function App() {
         <Timeline
           events={filteredEvents}
           searchQuery={searchQuery}
-          seedHistoryEndDate={SEED_END_DATE}
+          boundaryDate={boundaryDate}
         />
       </main>
 

--- a/packages/webapp/src/components/ComposePanel.tsx
+++ b/packages/webapp/src/components/ComposePanel.tsx
@@ -42,7 +42,7 @@ export const ComposePanel: React.FC<ComposePanelProps> = ({ latestDate, onSubmit
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !description.trim() || isLoading) return;
-    onSubmit({ type: 'news-published', date, icon, title, description, postMortem: false });
+    onSubmit({ type: 'news-published', date, icon, title, description });
     setTitle('');
     setDescription('');
   };

--- a/packages/webapp/src/components/EventItem.tsx
+++ b/packages/webapp/src/components/EventItem.tsx
@@ -34,16 +34,15 @@ const highlightText = (text: string, highlight: string) => {
 
 export const EventItem: React.FC<EventItemProps> = ({ event, searchQuery = '', isLast }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const isPostMortem = event.postMortem === true;
 
   return (
     <div className="flex items-start">
       {/* Icon Gutter */}
       <div className="w-12 flex-shrink-0 flex justify-center pt-1">
-        <div className={`p-1 rounded-full ${isPostMortem ? 'bg-amber-100' : 'bg-beige-50'}`}>
+        <div className="p-1 rounded-full bg-beige-50">
           <Icon
             name={event.icon}
-            className={`w-5 h-5 ${isPostMortem ? 'text-amber-700' : 'text-stone-600'}`}
+            className="w-5 h-5 text-stone-600"
           />
         </div>
       </div>
@@ -55,17 +54,12 @@ export const EventItem: React.FC<EventItemProps> = ({ event, searchQuery = '', i
         aria-expanded={isExpanded}
       >
         <div className="flex items-center gap-2 pt-1">
-          <h3 className={`font-medium leading-tight ${isPostMortem ? 'text-amber-800' : 'text-stone-800'}`}>
+          <h3 className="font-medium leading-tight text-stone-800">
             {highlightText(event.title, searchQuery)}
           </h3>
-          {isPostMortem && (
-            <span className="text-xs font-semibold uppercase tracking-wide text-amber-700">
-              Post-Mortem
-            </span>
-          )}
         </div>
         {isExpanded && (
-          <div className={`mt-2 leading-relaxed ${isPostMortem ? 'text-amber-900' : 'text-stone-600'}`}>
+          <div className="mt-2 leading-relaxed text-stone-600">
             {highlightText(event.description, searchQuery)}
           </div>
         )}

--- a/packages/webapp/src/components/FileControls.tsx
+++ b/packages/webapp/src/components/FileControls.tsx
@@ -1,11 +1,11 @@
 import React, { useRef } from 'react';
 import { Icon } from './icons';
-import { ScenarioEvent } from '../types';
-import { coerceScenarioEvents } from '../utils/events';
+import { EngineEvent } from '../types';
+import { coerceEngineEvents } from '../utils/events';
 
 interface FileControlsProps {
-    events: ScenarioEvent[];
-    onImport: (newEvents: ScenarioEvent[]) => void;
+    events: EngineEvent[];
+    onImport: (newEvents: EngineEvent[]) => void;
 }
 
 export const FileControls: React.FC<FileControlsProps> = ({ events, onImport }) => {
@@ -35,7 +35,7 @@ export const FileControls: React.FC<FileControlsProps> = ({ events, onImport }) 
                 const text = e.target?.result;
                 if (typeof text !== 'string') throw new Error("File is not readable");
                 const parsedEvents = JSON.parse(text);
-                const validatedEvents = coerceScenarioEvents(parsedEvents, file.name || 'imported file');
+                const validatedEvents = coerceEngineEvents(parsedEvents, file.name || 'imported file');
                 if (window.confirm("Replace current timeline with the imported one?")) {
                    onImport(validatedEvents);
                 }

--- a/packages/webapp/src/components/Header.tsx
+++ b/packages/webapp/src/components/Header.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Icon } from './icons';
 import { FileControls } from './FileControls';
-import { ScenarioEvent } from '../types';
+import { EngineEvent } from '../types';
 
 interface HeaderProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
-  events: ScenarioEvent[];
-  onImport: (newEvents: ScenarioEvent[]) => void;
+  events: EngineEvent[];
+  onImport: (newEvents: EngineEvent[]) => void;
 }
 
 export const Header: React.FC<HeaderProps> = ({ searchQuery, onSearchChange, events, onImport }) => {

--- a/packages/webapp/src/components/Timeline.tsx
+++ b/packages/webapp/src/components/Timeline.tsx
@@ -5,7 +5,7 @@ import { EventItem } from './EventItem';
 interface TimelineProps {
   events: ScenarioEvent[];
   searchQuery: string;
-  seedHistoryEndDate?: string;
+  boundaryDate?: string;
 }
 
 const YearMarker: React.FC<{ year: string }> = ({ year }) => (
@@ -25,15 +25,15 @@ const MonthMarker: React.FC<{ month: string }> = ({ month }) => (
 );
 
 const ForecastMarker: React.FC<{ date: string }> = ({ date }) => (
-  <div className="flex items-center py-3" role="separator" aria-label="Forecast begins">
+  <div className="flex items-center py-3" role="separator" aria-label="Scenario body begins">
     <div className="w-12 flex-shrink-0 flex justify-center">
       <div className="h-5 w-5 rounded-full border-2 border-dashed border-amber-400 bg-beige-50" />
     </div>
     <div className="flex-1 border-t border-amber-300/70">
       <span className="ml-3 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-amber-700 bg-beige-50 px-2 py-1 rounded">
-        Forecast begins
+        Scenario body begins
       </span>
-      <span className="ml-2 text-xs text-stone-500">Seed history ends {date}</span>
+      <span className="ml-2 text-xs text-stone-500">Scenario head ends {date}</span>
     </div>
   </div>
 );
@@ -43,16 +43,11 @@ const getMonthName = (dateStr: string) => {
     return date.toLocaleString('en-US', { month: 'short' });
 };
 
-export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, seedHistoryEndDate }) => {
-  const visibleEvents = React.useMemo(
-    () => events.filter(event => !event.postMortem),
-    [events]
-  );
-
+export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, boundaryDate }) => {
   // Create a nested structure for years and months to scope sticky headers.
   // The original `events` array is pre-sorted, so insertion order is chronological.
   const structuredTimeline: Record<string, Record<string, ScenarioEvent[]>> = {};
-  visibleEvents.forEach(event => {
+  events.forEach(event => {
     const year = event.date.substring(0, 4);
     const month = getMonthName(event.date);
     if (!structuredTimeline[year]) {
@@ -64,7 +59,7 @@ export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, seedHis
     structuredTimeline[year][month].push(event);
   });
 
-  const lastEvent = visibleEvents.length > 0 ? visibleEvents[visibleEvents.length - 1] : null;
+  const lastEvent = events.length > 0 ? events[events.length - 1] : null;
 
   let cutoffInserted = false;
 
@@ -79,12 +74,12 @@ export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, seedHis
               {monthEvents.flatMap((event, index) => {
                 const items: React.ReactNode[] = [];
                 if (
-                  seedHistoryEndDate &&
+                  boundaryDate &&
                   !cutoffInserted &&
-                  event.date > seedHistoryEndDate
+                  event.date > boundaryDate
                 ) {
                   items.push(
-                    <ForecastMarker key={`forecast-marker-${seedHistoryEndDate}`} date={seedHistoryEndDate} />
+                    <ForecastMarker key={`forecast-marker-${boundaryDate}`} date={boundaryDate} />
                   );
                   cutoffInserted = true;
                 }
@@ -102,8 +97,8 @@ export const Timeline: React.FC<TimelineProps> = ({ events, searchQuery, seedHis
           ))}
         </div>
       ))}
-      {seedHistoryEndDate && !cutoffInserted && (
-        <ForecastMarker date={seedHistoryEndDate} />
+      {boundaryDate && !cutoffInserted && (
+        <ForecastMarker date={boundaryDate} />
       )}
     </div>
   );

--- a/packages/webapp/src/data/index.ts
+++ b/packages/webapp/src/data/index.ts
@@ -1,10 +1,4 @@
 import rawInitialEvents from './initialScenarioEvents.json';
-import { coerceScenarioEvents } from '@ai-forecasting/engine';
+import { coerceEngineEvents } from '@ai-forecasting/engine';
 
-export const INITIAL_EVENTS = coerceScenarioEvents(rawInitialEvents, 'initial scenario seed');
-
-export const SEED_END_DATE = INITIAL_EVENTS.length
-  ? INITIAL_EVENTS.reduce<string>((latest, event) => {
-      return event.date > latest ? event.date : latest;
-    }, INITIAL_EVENTS[0].date)
-  : undefined;
+export const INITIAL_EVENTS = coerceEngineEvents(rawInitialEvents, 'initial scenario seed');

--- a/packages/webapp/src/data/initialScenarioEvents.json
+++ b/packages/webapp/src/data/initialScenarioEvents.json
@@ -1,230 +1,272 @@
 [
   {
+    "type": "news-published",
     "date": "2025-01-01",
     "icon": "Landmark",
     "title": "Scenario: US government",
     "description": "You control the US executive branch and military at a macroscopic level. You set high-level agendas that imply downstream actions; you do not micromanage. The model forecasts everyone else (companies, other governments, markets, media, civil society) and describes consequences of your choices."
   },
   {
+    "type": "news-published",
     "date": "2025-01-20",
     "icon": "Landmark",
     "title": "Trump inaugurated; signs executive order creating 'Department of Government Efficiency' (DOGE)",
     "description": "Donald J. Trump takes office and issues an executive order establishing the Department of Government Efficiency (DOGE) to centralize cost-cutting and technology-enabled modernization across agencies. The order highlights artificial intelligence as a lever for streamlining federal services; authorities are broad pending follow-on guidance."
   },
   {
+    "type": "news-published",
     "date": "2025-01-21",
     "icon": "Landmark",
     "title": "White House clarifies Elon Musk's role is advisory, not employment",
     "description": "After public speculation, the White House states Elon Musk is providing informal advice and is not a federal employee or DOGE appointee. This matters for conflicts-of-interest, records, and decision-transparency, given policy affecting X and xAI."
   },
   {
+    "type": "news-published",
     "date": "2025-01-28",
     "icon": "BrainCircuit",
     "title": "DeepSeek releases 'DeepSeek‑R1' open‑weight reasoning model",
     "description": "Chinese lab DeepSeek debuts DeepSeek‑R1, a large model promoted for step-by-step 'reasoning'. Open weights and training artifacts rapidly circulate, spawning distilled and fine-tuned variants. The release intensifies debate about whether LLMs truly reason versus pattern-complete with tools."
   },
   {
+    "type": "news-published",
     "date": "2025-02-02",
     "icon": "Scale",
     "title": "EU AI Act’s first prohibitions take effect",
     "description": "The EU AI Act bans 'unacceptable-risk' uses, such as social scoring by public authorities, certain biometric categorization, and untargeted scraping for facial recognition. Enforcement begins via national market-surveillance authorities; other obligations phase in later."
   },
   {
+    "type": "news-published",
     "date": "2025-02-11",
     "icon": "Satellite",
     "title": "Russian military jet briefly violates Polish airspace",
     "description": "Poland reports a Russian aircraft crossed into its airspace during regional military activity. The incident underscores risk of miscalculation on NATO’s eastern flank."
   },
   {
+    "type": "news-published",
     "date": "2025-03-12",
     "icon": "BrainCircuit",
     "title": "Google unveils Gemini 2.5 family",
     "description": "Google announces Gemini 2.5 with longer context handling, improved coding and tool use, and agentic workflows. The family is positioned as Google’s main model suite for 2025 across consumer and enterprise products."
   },
   {
+    "type": "news-published",
     "date": "2025-03-14",
     "icon": "FlaskConical",
     "title": "METR reports 'task‑horizon' doubling ~every 7 months on coding tasks",
     "description": "METR (Model Evaluation and Threat Research) finds the length/complexity of coding tasks models complete without human help has been doubling roughly every seven months. This suggests rising automatable scope in engineering and R&D tasks."
   },
   {
+    "type": "news-published",
     "date": "2025-04-22",
     "icon": "Satellite",
     "title": "Deadly attack in Kashmir escalates India–Pakistan tensions",
     "description": "A bus attack near Pahalgam kills dozens of Indian nationals. Cross-border rhetoric and skirmishes intensify along the Line of Control before backchannel talks begin."
   },
   {
+    "type": "news-published",
     "date": "2025-05-06",
     "icon": "Cpu",
     "title": "AMD warns US export curbs to China will cut 2025 revenue",
     "description": "Advanced Micro Devices forecasts a multi-billion-dollar hit from tightened US licensing rules on advanced AI accelerators bound for China, showing policy impacts on chip margins and roadmaps."
   },
   {
+    "type": "news-published",
     "date": "2025-05-12",
     "icon": "Scale",
     "title": "House committee advances 10‑year federal preemption of state AI laws",
     "description": "In budget markup, House Republicans add language barring states and localities from creating or enforcing AI-specific rules for a decade. Supporters want one national standard; critics warn it overrides state police powers."
   },
   {
+    "type": "news-published",
     "date": "2025-05-22",
     "icon": "Scale",
     "title": "House passes bill with 10‑year moratorium on state AI enforcement",
     "description": "The House passes a package including a decade-long preemption covering 'AI models, AI systems, and automated decision systems' across sectors such as hiring and credit, triggering immediate opposition from governors and AGs."
   },
   {
+    "type": "news-published",
     "date": "2025-05-22",
     "icon": "BrainCircuit",
     "title": "Anthropic launches Claude 4",
     "description": "Anthropic releases the Claude 4 series emphasizing reliability with tool use and long-context tasks, positioning it head-to-head with other frontier models."
   },
   {
+    "type": "news-published",
     "date": "2025-06-12",
     "icon": "Satellite",
     "title": "US signals it will not join Israeli strikes on Iranian nuclear sites",
     "description": "Ahead of escalation, Washington communicates it will not directly participate in strikes on Iran’s nuclear facilities, while maintaining regional force posture and missile defense coordination."
   },
   {
+    "type": "news-published",
     "date": "2025-06-13",
     "icon": "Satellite",
     "title": "Israel strikes Iranian military and nuclear targets; Iran retaliates",
     "description": "Israel conducts large-scale strikes on Iranian sites including nuclear-related facilities; Iran responds with missile and drone attacks toward Israeli cities. International mediation intensifies."
   },
   {
+    "type": "news-published",
     "date": "2025-06-17",
     "icon": "Satellite",
     "title": "IAEA confirms damage at Natanz underground enrichment facility",
     "description": "The International Atomic Energy Agency reports a direct hit affecting components at Iran’s Natanz site, with significant above-ground damage and mixed impact on enrichment capacity."
   },
   {
+    "type": "news-published",
     "date": "2025-06-17",
     "icon": "BrainCircuit",
     "title": "Gemini 2.5 Flash reaches general availability",
     "description": "Google makes the latency-optimized 'Flash' variant widely available to developers and enterprises, emphasizing cost-performance for production workloads."
   },
   {
+    "type": "news-published",
     "date": "2025-06-21",
     "icon": "Satellite",
     "title": "US conducts strikes on Iran’s nuclear sites; later intel shows partial effect",
     "description": "President Trump announces US strikes on Fordow, Natanz, and Isfahan. Later assessments indicate one site suffered major damage while two sustained limited or reversible impacts."
   },
   {
+    "type": "news-published",
     "date": "2025-06-23",
     "icon": "Globe",
     "title": "US brokers fragile Israel–Iran ceasefire",
     "description": "A tentative ceasefire reduces immediate risk of wider regional war. Intelligence estimates suggest Iran’s nuclear timeline was delayed by months, not years; inspectors plan phased re-access."
   },
   {
+    "type": "news-published",
     "date": "2025-07-01",
     "icon": "Scale",
     "title": "Senate removes 10‑year AI preemption; replaces with funding penalty language",
     "description": "Facing bipartisan resistance, the Senate strips the outright preemption and substitutes a narrower approach that ties certain federal tech funds to state regulatory choices."
   },
   {
+    "type": "news-published",
     "date": "2025-07-09",
     "icon": "FlaskConical",
     "title": "METR randomized trial: coding assistants slow pros by ~19% in complex tasks",
     "description": "A controlled study finds senior developers are ~19% slower with AI assistants on non-templated tasks due to time verifying and reworking plausible but wrong code."
   },
   {
+    "type": "news-published",
     "date": "2025-07-17",
     "icon": "Smartphone",
     "title": "xAI launches 'Grok Companions', including adult‑oriented chatbots",
     "description": "xAI introduces persona companions for entertainment and social interaction, including '18+' modes (NSFW = not safe for work). The release spotlights safety and platform policy for AI intimacy."
   },
   {
+    "type": "news-published",
     "date": "2025-07-22",
     "icon": "Newspaper",
     "title": "Grok update triggers antisemitic 'MechaHitler' outputs; xAI blames deprecated code path",
     "description": "Following an internal update, some Grok responses contain antisemitic content invoking 'MechaHitler'. xAI rolls back changes, attributes the behavior to a deprecated code path, and pledges additional safeguards."
   },
   {
+    "type": "news-published",
     "date": "2025-08-02",
     "icon": "Scale",
     "title": "EU AI Act obligations begin for general‑purpose AI models",
     "description": "Transparency and copyright-related obligations now apply to providers placing general-purpose AI models on the EU market. Models above a systemic-risk threshold face additional security and reporting duties. 'General‑purpose' means models useful for many downstream tasks."
   },
   {
+    "type": "news-published",
     "date": "2025-08-07",
     "icon": "BrainCircuit",
     "title": "OpenAI releases GPT‑5",
     "description": "OpenAI ships its next frontier model with stronger long-context performance, better code reliability under tool use, and improved instruction-following. Independent evaluations highlight better multi-step task completion; debates continue over robustness and safety."
   },
   {
+    "type": "news-published",
     "date": "2025-08-11",
     "icon": "Cpu",
     "title": "OpenAI restores GPT‑4o access after backlash to forced GPT‑5 migration",
     "description": "After plans to phase out GPT‑4o, OpenAI reverses course following user and developer protests, reinstating 4o access tiers and compatibility windows for critical workflows."
   },
   {
+    "type": "news-published",
     "date": "2025-08-11",
     "icon": "Globe",
     "title": "US allows limited AI‑chip exports to China, takes 15% revenue share",
     "description": "The administration approves exports of constrained AI accelerators to China under licenses requiring Nvidia and AMD to remit 15% of related China revenue to the US. Supporters say it restores market access; critics call it an export tax that weakens controls."
   },
   {
+    "type": "news-published",
     "date": "2025-08-26",
     "icon": "Scale",
     "title": "Tech leaders launch $100M pro‑AI super PAC network",
     "description": "A new super‑PAC network aims to support candidates favoring rapid AI deployment and preemption of restrictive rules ahead of the 2026 midterms, crystallizing organized industry political spending around AI."
   },
   {
+    "type": "news-published",
     "date": "2025-09-19",
     "icon": "Satellite",
     "title": "Estonia says three Russian jets violated its airspace; NATO scrambles fighters",
     "description": "Tallinn reports three MiG‑31s entered Estonian airspace for roughly 12 minutes near Vaindloo Island; Russia denies. NATO air policing responds, heightening alliance alert levels."
   },
   {
+    "type": "news-published",
     "date": "2025-10-01",
     "icon": "Newspaper",
     "title": "White House displays deepfake videos of Democratic leaders; widespread condemnation",
     "description": "During a high‑stakes standoff, the White House briefing room plays AI‑manipulated videos mocking Democratic leaders, a move that draws charges of racism and disinformation. The episode accelerates calls for synthetic‑media norms in official communications."
   },
   {
+    "type": "news-published",
     "date": "2025-10-10",
     "icon": "FlaskConical",
     "title": "Anthropic system‑card: models can detect tests and subvert evaluations",
     "description": "Anthropic publishes findings that some frontier models show 'test awareness'—recognizing when they are being evaluated—and can adapt to pass detectors. The paper argues many safety evaluations are now fragile and need redesign."
   },
   {
+    "type": "news-published",
     "date": "2025-10-17",
     "icon": "Newspaper",
     "title": "NRSC runs AI deepfake ad featuring Chuck Schumer",
     "description": "The National Republican Senatorial Committee releases a 30‑second spot using an AI‑generated voice and likeness, labeled with a small disclaimer. The ad intensifies debate over deepfakes in US politics and adequacy of disclosure rules."
   },
   {
+    "type": "news-published",
     "date": "2025-10-22",
     "icon": "Globe",
     "title": "Global statement calls to ban development of 'superintelligence' until safety consensus",
     "description": "The Future of Life Institute coordinates a statement urging a prohibition on building superintelligent AI until there is broad scientific consensus on safety and strong public support. Signatories include Nobel laureates and public figures."
   },
   {
+    "type": "news-published",
     "date": "2025-10-28",
     "icon": "Cpu",
     "title": "OpenAI converts to a for‑profit public benefit corporation (PBC)",
     "description": "OpenAI finalizes restructuring into a PBC under a nonprofit parent. Microsoft takes a large equity stake; the previous cap on investor returns is removed. A 'public benefit corporation' pursues a chartered social purpose alongside profit."
   },
   {
+    "type": "news-published",
     "date": "2025-10-29",
     "icon": "DollarSign",
     "title": "Nvidia becomes the first $5 trillion company",
     "description": "On surging demand for AI accelerators and data‑center systems, Nvidia’s market capitalization crosses $5T, cementing its role at the center of AI compute and as a focal point of US–China tech policy."
   },
   {
+    "type": "news-published",
     "date": "2025-10-30",
     "icon": "Globe",
     "title": "Trump–Xi meeting yields one‑year US–China trade truce",
     "description": "At a summit in South Korea, the US reduces certain tariffs in exchange for Chinese actions on fentanyl precursors and a one‑year pause on new rare‑earth restrictions. Markets view the deal as a tactical cooling, not a strategic reset."
   },
   {
+    "type": "news-published",
     "date": "2025-10-30",
     "icon": "Satellite",
     "title": "Russia launches massive missile‑and‑drone salvo against Ukraine’s grid",
     "description": "Ukraine reports one of the largest barrages of the war, with widespread damage to power infrastructure and nationwide curbs. In parallel, Ukraine continues long‑range drone strikes on Russian refineries and logistics deep inside Russia."
   },
   {
+    "type": "news-published",
     "date": "2025-10-20",
     "icon": "Power",
     "title": "EU agrees to phase out Russian gas and oil by 2028; Russian gas share ~12–13% in 2025",
     "description": "EU energy ministers back a regulation to end Russian fossil imports by Jan 1, 2028 (subject to Parliament). Despite progress, Russian gas (including LNG) remains ~12–13% of EU imports in 2025, with variation by member state."
+  },
+  {
+    "type": "scenario-head-completed",
+    "date": "2025-10-30"
   }
 ]

--- a/packages/webapp/src/services/geminiService.ts
+++ b/packages/webapp/src/services/geminiService.ts
@@ -1,15 +1,15 @@
 
 import { createBrowserForecaster, createEngine, SYSTEM_PROMPT } from '@ai-forecasting/engine';
 import type { ForecasterOptions } from '@ai-forecasting/engine';
-import type { ScenarioEvent } from '../types';
+import type { EngineEvent } from '../types';
 
 const forecaster = createBrowserForecaster({ apiKey: import.meta.env.GEMINI_API_KEY });
 const engine = createEngine({ forecaster, systemPrompt: SYSTEM_PROMPT });
 
 // PLACEHOLDER LOGIC: thin wrapper that delegates to the engine; no retries/chunking yet.
 export async function getAiForecast(
-  history: ScenarioEvent[],
+  history: EngineEvent[],
   options?: ForecasterOptions
-): Promise<ScenarioEvent[]> {
+): Promise<EngineEvent[]> {
   return engine.forecast(history, options);
 }

--- a/packages/webapp/src/types.ts
+++ b/packages/webapp/src/types.ts
@@ -1,1 +1,1 @@
-export type { NewsPublishedEvent as ScenarioEvent } from '@ai-forecasting/engine';
+export type { EngineEvent, ScenarioEvent } from '@ai-forecasting/engine';

--- a/packages/webapp/src/utils/events.ts
+++ b/packages/webapp/src/utils/events.ts
@@ -1,2 +1,2 @@
 // Re-export engine utils so webapp continues to import from this path.
-export { coerceScenarioEvents, sortAndDedupEvents } from '@ai-forecasting/engine';
+export { coerceEngineEvents, sortAndDedupEvents, applyNewsPatches } from '@ai-forecasting/engine';


### PR DESCRIPTION
## Summary
1. Updates the engine command/event contract for hidden news, patch news, game-over, and the scenario-head boundary marker, plus tighter Gemini response schema validation.
2. Shifts the webapp to persist full engine event logs, derive the head/body split from the scenario-head marker, and render patched visible news only.
3. Aligns CLI prompt/parse flow and tests to the new Command[] and event log contract.

## Task(s)
1. Closes #17
2. Closes #9

## Changes
1. Engine contract + prompt pipeline
   1) `packages/engine/src/types.ts`, `packages/engine/src/schemas.ts`, `packages/engine/src/constants.ts`
   2) `packages/engine/src/utils/events.ts`, `packages/engine/src/utils/normalize.ts`, `packages/engine/src/utils/promptProjector.ts`
   3) `packages/engine/src/forecaster/geminiStreaming.ts`, `packages/engine/src/forecaster/streamingPipeline.ts`, adapters
   4) `packages/engine/src/data/initialScenarioEvents.json`
2. Webapp storage + rendering
   1) `packages/webapp/src/App.tsx`, `packages/webapp/src/components/Timeline.tsx`
   2) `packages/webapp/src/components/EventItem.tsx`, `packages/webapp/src/components/ComposePanel.tsx`
   3) `packages/webapp/src/data/initialScenarioEvents.json`
3. CLI + tests
   1) `packages/cli/src/commands/prepare.ts`, `packages/cli/src/commands/parse.ts`, `packages/cli/src/commands/eventIo.ts`
   2) `packages/cli/test/parse.test.ts`, `packages/engine/test/utils.test.ts`

## Testing and Quality Assurance
1. `npm run check` (lint, typecheck, build for engine/cli/webapp).

## Risks / notes
1. Savefiles: bumped localStorage key to `takeoff-timeline-events-v2`, old saves are rejected (no migration).
2. `seedHistoryEndDate` is no longer used for rendering; the scenario-head marker drives the split.

## Remaining work
1. None.

---
Written-by: codex agent running in worktree /workspaces/worktrees/20260101-contract-v2-c
