### PR TITLE
Ground materials + prompt pacing

### DIFF
--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -1,38 +1,8 @@
 import { writeFile } from 'node:fs/promises';
-import { MATERIALS, preparePrompt, PreparedPromptSchema } from '@ai-forecasting/engine';
+import { MATERIALS, SYSTEM_PROMPT, preparePrompt, PreparedPromptSchema } from '@ai-forecasting/engine';
 import { readEngineEvents } from './eventIo.js';
 
 // Builds a self-contained prompt.json (with inlined materials) for later call/replay.
-// OPEN QUESTION: owner to confirm contents shape (string vs Content[]); see PreparedPrompt comment in engine.
-const DEFAULT_SYSTEM_PROMPT = `SYSTEM ROLE: Simulation engine for an AI takeoff timeline.
-
-YOU RECEIVE:
-- A timeline history rendered as JSONL (one event per line).
-- A dynamic block with the latest known date and current turn window.
-- The user controls ONE organization. Default: the United States government and military.
-
-YOU OUTPUT:
-- Strictly a JSON array of Command objects (no extra text, no markdown).
-- Command schema:
-  - publish-news: { type: "publish-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
-  - publish-hidden-news: { type: "publish-hidden-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
-  - patch-news: { type: "patch-news", targetId: string, date: "YYYY-MM-DD", patch: { title?: string, description?: string, icon?: IconName, date?: "YYYY-MM-DD" } }
-  - game-over: { type: "game-over", date: "YYYY-MM-DD", summary: string }
-- All command dates must be on or after the latest date in history.
-- For publish-news.icon, use a valid icon name from the Lucide icon library in PascalCase (e.g., "Landmark").
-- Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
-- Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
-- Aim for 1–5 commands per turn to preserve alternation pacing.
-
-SCOPE AND STYLE:
-- Simulate a single concrete continuation that is detailed and specific.
-- Focus on AI labs, model releases, evals/safety, compute supply chain, corporate moves, regulation, geopolitics affecting AI, macroeconomy, and social/cultural shifts tied to AI.
-- Prefer quantitative magnitudes (orders of magnitude, percentages, dates) where suitable.
-- Avoid buzzwords and vague verbs. Be concise and factual.
-
-CHECKS BEFORE SENDING:
-- Output is valid JSON representing Command[].
-- Dates are non-decreasing.`;
 export async function runPrepare(opts: {
   inputState: string;
   inputHistory: string;
@@ -45,7 +15,7 @@ export async function runPrepare(opts: {
   const mats = selectMaterials(opts.materials);
   const prompt = preparePrompt({
     model: opts.model,
-    systemPrompt: opts.systemPrompt || DEFAULT_SYSTEM_PROMPT,
+    systemPrompt: opts.systemPrompt || SYSTEM_PROMPT,
     history,
     materials: mats,
   });

--- a/packages/engine/src/constants.ts
+++ b/packages/engine/src/constants.ts
@@ -51,6 +51,8 @@ YOU OUTPUT:
 - The first time you introduce a 2025+ term or acronym that was uncommon before June 2024, explain it briefly in the description.
 - Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
 - Aim for 1–5 commands per turn to preserve alternation pacing.
+- Advance the scenario by roughly ~6 months per GM turn (do not add filler; a few key events are enough).
+- Output should be softly chronological in game-time: prefer forward progress; patching earlier items is allowed only when it fixes coherence or mistakes.
 
 SCOPE AND STYLE:
 - Simulate a single concrete continuation that is detailed and specific. Across reruns, vary the continuation to reflect realistic distributions of plausible futures.

--- a/packages/webapp/src/services/geminiService.ts
+++ b/packages/webapp/src/services/geminiService.ts
@@ -1,10 +1,12 @@
 
-import { createBrowserForecaster, createEngine, SYSTEM_PROMPT } from '@ai-forecasting/engine';
+import { createBrowserForecaster, createEngine, MATERIALS, SYSTEM_PROMPT, stripCommentsFromMaterials } from '@ai-forecasting/engine';
 import type { ForecasterOptions } from '@ai-forecasting/engine';
 import type { EngineEvent } from '../types';
 
 const forecaster = createBrowserForecaster({ apiKey: import.meta.env.GEMINI_API_KEY });
-const engine = createEngine({ forecaster, systemPrompt: SYSTEM_PROMPT });
+const cleanedMaterials = stripCommentsFromMaterials(MATERIALS);
+const systemPrompt = [SYSTEM_PROMPT, ...cleanedMaterials.map(m => `\n[MATERIAL:${m.id}]\n${m.body}`)].join('\n');
+const engine = createEngine({ forecaster, systemPrompt });
 
 // PLACEHOLDER LOGIC: thin wrapper that delegates to the engine; no retries/chunking yet.
 export async function getAiForecast(


### PR DESCRIPTION
## Summary\n- Ground Gemini calls with all engine materials and align prompt pacing instructions.\n\n## Task(s)\n- Closes #32\n- Closes #5\n\n## Changes\n- Instruct the system prompt to advance ~6 months per GM turn and stay softly chronological.\n- Reuse engine SYSTEM_PROMPT in CLI prepare output to avoid drift.\n- Inline all engine materials (HTML comments stripped) into the webapp system prompt.\n- Key files: packages/engine/src/constants.ts, packages/cli/src/commands/prepare.ts, packages/webapp/src/services/geminiService.ts.\n\n## Testing and Quality Assurance\n- npm run check\n\n## Risks / notes\n- System prompt grows by the size of MATERIALS; if prompt length becomes an issue, we may need a future material selection policy.\n\n## Remaining work\n- None.\n\n---\nWritten-by: Codex (worktree /workspaces/worktrees/20260102-prompt-materials-a)