### PR TITLE
Align prompt pacing and materials grounding

### DIFF
--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -1,38 +1,10 @@
 import { writeFile } from 'node:fs/promises';
-import { MATERIALS, preparePrompt, PreparedPromptSchema } from '@ai-forecasting/engine';
+import { MATERIALS, SYSTEM_PROMPT, preparePrompt, PreparedPromptSchema } from '@ai-forecasting/engine';
 import { readEngineEvents } from './eventIo.js';
 
 // Builds a self-contained prompt.json (with inlined materials) for later call/replay.
 // OPEN QUESTION: owner to confirm contents shape (string vs Content[]); see PreparedPrompt comment in engine.
-const DEFAULT_SYSTEM_PROMPT = `SYSTEM ROLE: Simulation engine for an AI takeoff timeline.
-
-YOU RECEIVE:
-- A timeline history rendered as JSONL (one event per line).
-- A dynamic block with the latest known date and current turn window.
-- The user controls ONE organization. Default: the United States government and military.
-
-YOU OUTPUT:
-- Strictly a JSON array of Command objects (no extra text, no markdown).
-- Command schema:
-  - publish-news: { type: "publish-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
-  - publish-hidden-news: { type: "publish-hidden-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
-  - patch-news: { type: "patch-news", targetId: string, date: "YYYY-MM-DD", patch: { title?: string, description?: string, icon?: IconName, date?: "YYYY-MM-DD" } }
-  - game-over: { type: "game-over", date: "YYYY-MM-DD", summary: string }
-- All command dates must be on or after the latest date in history.
-- For publish-news.icon, use a valid icon name from the Lucide icon library in PascalCase (e.g., "Landmark").
-- Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
-- Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
-- Aim for 1–5 commands per turn to preserve alternation pacing.
-
-SCOPE AND STYLE:
-- Simulate a single concrete continuation that is detailed and specific.
-- Focus on AI labs, model releases, evals/safety, compute supply chain, corporate moves, regulation, geopolitics affecting AI, macroeconomy, and social/cultural shifts tied to AI.
-- Prefer quantitative magnitudes (orders of magnitude, percentages, dates) where suitable.
-- Avoid buzzwords and vague verbs. Be concise and factual.
-
-CHECKS BEFORE SENDING:
-- Output is valid JSON representing Command[].
-- Dates are non-decreasing.`;
+const DEFAULT_SYSTEM_PROMPT = SYSTEM_PROMPT;
 export async function runPrepare(opts: {
   inputState: string;
   inputHistory: string;

--- a/packages/engine/src/constants.ts
+++ b/packages/engine/src/constants.ts
@@ -51,6 +51,8 @@ YOU OUTPUT:
 - The first time you introduce a 2025+ term or acronym that was uncommon before June 2024, explain it briefly in the description.
 - Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
 - Aim for 1–5 commands per turn to preserve alternation pacing.
+- Each GM turn should advance the in-world timeline by roughly ~6 months beyond the latest known date.
+- Output is softly chronological in game-time: list events in increasing date order, prefer forward progress, and use patch-news only when corrections are necessary.
 
 SCOPE AND STYLE:
 - Simulate a single concrete continuation that is detailed and specific. Across reruns, vary the continuation to reflect realistic distributions of plausible futures.

--- a/packages/webapp/src/services/geminiService.ts
+++ b/packages/webapp/src/services/geminiService.ts
@@ -1,10 +1,12 @@
 
-import { createBrowserForecaster, createEngine, SYSTEM_PROMPT } from '@ai-forecasting/engine';
+import { createBrowserForecaster, createEngine, MATERIALS, SYSTEM_PROMPT, stripCommentsFromMaterials } from '@ai-forecasting/engine';
 import type { ForecasterOptions } from '@ai-forecasting/engine';
 import type { EngineEvent } from '../types';
 
 const forecaster = createBrowserForecaster({ apiKey: import.meta.env.GEMINI_API_KEY });
-const engine = createEngine({ forecaster, systemPrompt: SYSTEM_PROMPT });
+const cleanedMaterials = stripCommentsFromMaterials(MATERIALS);
+const systemPrompt = [SYSTEM_PROMPT, ...cleanedMaterials.map(m => `\n[MATERIAL:${m.id}]\n${m.body}`)].join('\n');
+const engine = createEngine({ forecaster, systemPrompt });
 
 // PLACEHOLDER LOGIC: thin wrapper that delegates to the engine; no retries/chunking yet.
 export async function getAiForecast(


### PR DESCRIPTION
## Summary
- align GM prompt pacing/chronology with engine SYSTEM_PROMPT
- inline all engine materials into webapp Gemini systemInstruction with comment stripping

## Task(s)
- Closes #32
- Closes #5

## Changes
- add 6-month pacing + soft chronology instructions to `packages/engine/src/constants.ts`
- make CLI default system prompt reuse engine `SYSTEM_PROMPT` in `packages/cli/src/commands/prepare.ts`
- inline engine materials (comment-stripped) into webapp system prompt in `packages/webapp/src/services/geminiService.ts`

## Testing and Quality Assurance
- `npm run check`

## Risks / notes
- system prompt grows with full materials; if prompt size becomes an issue, we may need a future scoping strategy

## Remaining work
- none

---
Written-by: Codex (worktree /workspaces/worktrees/20260102-prompt-materials-b)
