### PR TITLE
Ground system prompt pacing and materials

### DIFF
--- a/packages/cli/src/commands/prepare.ts
+++ b/packages/cli/src/commands/prepare.ts
@@ -1,38 +1,10 @@
 import { writeFile } from 'node:fs/promises';
-import { MATERIALS, preparePrompt, PreparedPromptSchema } from '@ai-forecasting/engine';
+import { MATERIALS, preparePrompt, PreparedPromptSchema, SYSTEM_PROMPT } from '@ai-forecasting/engine';
 import { readEngineEvents } from './eventIo.js';
 
 // Builds a self-contained prompt.json (with inlined materials) for later call/replay.
 // OPEN QUESTION: owner to confirm contents shape (string vs Content[]); see PreparedPrompt comment in engine.
-const DEFAULT_SYSTEM_PROMPT = `SYSTEM ROLE: Simulation engine for an AI takeoff timeline.
-
-YOU RECEIVE:
-- A timeline history rendered as JSONL (one event per line).
-- A dynamic block with the latest known date and current turn window.
-- The user controls ONE organization. Default: the United States government and military.
-
-YOU OUTPUT:
-- Strictly a JSON array of Command objects (no extra text, no markdown).
-- Command schema:
-  - publish-news: { type: "publish-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
-  - publish-hidden-news: { type: "publish-hidden-news", id?: string, date: "YYYY-MM-DD", icon: IconName, title: string, description: string }
-  - patch-news: { type: "patch-news", targetId: string, date: "YYYY-MM-DD", patch: { title?: string, description?: string, icon?: IconName, date?: "YYYY-MM-DD" } }
-  - game-over: { type: "game-over", date: "YYYY-MM-DD", summary: string }
-- All command dates must be on or after the latest date in history.
-- For publish-news.icon, use a valid icon name from the Lucide icon library in PascalCase (e.g., "Landmark").
-- Titles state the core fact in plain language. Descriptions add enough context for a reader whose knowledge cutoff is June 1, 2024.
-- Never take actions reserved for the user-controlled organization. You may describe consequences and third-party reactions.
-- Aim for 1–5 commands per turn to preserve alternation pacing.
-
-SCOPE AND STYLE:
-- Simulate a single concrete continuation that is detailed and specific.
-- Focus on AI labs, model releases, evals/safety, compute supply chain, corporate moves, regulation, geopolitics affecting AI, macroeconomy, and social/cultural shifts tied to AI.
-- Prefer quantitative magnitudes (orders of magnitude, percentages, dates) where suitable.
-- Avoid buzzwords and vague verbs. Be concise and factual.
-
-CHECKS BEFORE SENDING:
-- Output is valid JSON representing Command[].
-- Dates are non-decreasing.`;
+const DEFAULT_SYSTEM_PROMPT = SYSTEM_PROMPT;
 export async function runPrepare(opts: {
   inputState: string;
   inputHistory: string;

--- a/packages/engine/src/constants.ts
+++ b/packages/engine/src/constants.ts
@@ -57,6 +57,8 @@ SCOPE AND STYLE:
 - Focus on AI labs, model releases, evals/safety, compute supply chain, corporate moves, regulation, geopolitics affecting AI, macroeconomy, and social/cultural shifts tied to AI.
 - Prefer quantitative magnitudes (orders of magnitude, percentages, dates) where suitable.
 - Avoid buzzwords and vague verbs. Be concise and factual.
+- Advance the scenario by roughly ~6 months per game master turn. You do not need to add events for every month.
+- Output should be softly chronological in in-world time: prefer forward progression as the reader scrolls; patches are allowed to correct earlier items but avoid retroactive edits unless needed for coherence.
 
 CHECKS BEFORE SENDING:
 - Output is valid JSON representing Command[].

--- a/packages/webapp/src/services/geminiService.ts
+++ b/packages/webapp/src/services/geminiService.ts
@@ -1,10 +1,15 @@
 
-import { createBrowserForecaster, createEngine, SYSTEM_PROMPT } from '@ai-forecasting/engine';
+import { createBrowserForecaster, createEngine, MATERIALS, SYSTEM_PROMPT, stripCommentsFromMaterials } from '@ai-forecasting/engine';
 import type { ForecasterOptions } from '@ai-forecasting/engine';
 import type { EngineEvent } from '../types';
 
 const forecaster = createBrowserForecaster({ apiKey: import.meta.env.GEMINI_API_KEY });
-const engine = createEngine({ forecaster, systemPrompt: SYSTEM_PROMPT });
+const cleanedMaterials = stripCommentsFromMaterials(MATERIALS);
+const systemPromptWithMaterials = [
+  SYSTEM_PROMPT,
+  ...cleanedMaterials.map(material => `\n[MATERIAL:${material.id}]\n${material.body}`),
+].join('\n');
+const engine = createEngine({ forecaster, systemPrompt: systemPromptWithMaterials });
 
 // PLACEHOLDER LOGIC: thin wrapper that delegates to the engine; no retries/chunking yet.
 export async function getAiForecast(


### PR DESCRIPTION
## Summary
- Add explicit ~6-month pacing and soft chronology guidance to the shared system prompt.
- Inline all engine materials into the webapp Gemini systemInstruction with comment stripping.
- Align CLI default prompt with the engine SYSTEM_PROMPT to avoid drift.

## Key Files
- `packages/engine/src/constants.ts`
- `packages/webapp/src/services/geminiService.ts`
- `packages/cli/src/commands/prepare.ts`

## Validation
- `npm run check`

## Tradeoffs / Risks
- Inlining all materials increases prompt size; no truncation or selection UI yet.

## Questions
- None.

Closes #32
Closes #5
