### PR TITLE
Turn markers + CLI turn command (a)

### DIFF
--- a/packages/cli/src/commands/turn.ts
+++ b/packages/cli/src/commands/turn.ts
@@ -1,0 +1,143 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { aggregate, sortAndDedupEvents, type EngineEvent } from '@ai-forecasting/engine';
+import { readEngineEvents, writeEventsJsonl } from './eventIo.js';
+import { runAggregate } from './aggregate.js';
+import { runPrepare } from './prepare.js';
+import { runCall } from './call.js';
+import { runParse } from './parse.js';
+
+export async function runTurn(opts: {
+  inputHistory: string;
+  inputState?: string;
+  newEvents: string;
+  outputHistory: string;
+  outputState: string;
+  outputPrompt: string;
+  outputResponse: string;
+  outputEvents: string;
+  materials?: string;
+  model: string;
+  systemPrompt: string;
+  apiKey?: string;
+  mock?: boolean;
+}) {
+  const history = await readEngineEvents(opts.inputHistory, 'input-history');
+  const playerEvents = await readEngineEvents(opts.newEvents, 'new-events');
+  if (playerEvents.length === 0) {
+    throw new Error('turn: --new-events is empty; expected at least one EngineEvent.');
+  }
+
+  const playerFrom = earliestDate(playerEvents);
+  const playerUntil = aggregate([...history, ...playerEvents]).latestDate ?? playerFrom;
+  const playerTurnStarted: EngineEvent = {
+    type: 'turn-started',
+    actor: 'player',
+    from: playerFrom,
+    until: playerFrom,
+  };
+  const playerTurnFinished: EngineEvent = {
+    type: 'turn-finished',
+    actor: 'player',
+    from: playerFrom,
+    until: playerUntil,
+  };
+  const historyWithPlayerTurn = sortAndDedupEvents([
+    ...history,
+    playerTurnStarted,
+    ...playerEvents,
+    playerTurnFinished,
+  ]);
+  const gmStartFrom = aggregate(historyWithPlayerTurn).latestDate ?? playerUntil;
+  const gmTurnStarted: EngineEvent = {
+    type: 'turn-started',
+    actor: 'game_master',
+    from: gmStartFrom,
+    until: gmStartFrom,
+  };
+  const historyForPrompt = sortAndDedupEvents([...historyWithPlayerTurn, gmTurnStarted]);
+
+  const workDir = await mkdtemp(join(tmpdir(), 'cli-turn-'));
+  const preHistoryPath = join(workDir, 'history-pre.jsonl');
+  const preStatePath = join(workDir, 'state-pre.json');
+  const finalHistoryPath = join(workDir, 'history-final.jsonl');
+
+  try {
+    await writeEventsJsonl(preHistoryPath, historyForPrompt);
+    await runAggregate({
+      inputHistory: preHistoryPath,
+      outputState: preStatePath,
+    });
+    await runPrepare({
+      inputState: opts.inputState ?? '',
+      inputHistory: preHistoryPath,
+      materials: opts.materials,
+      model: opts.model,
+      systemPrompt: opts.systemPrompt,
+      outputPrompt: opts.outputPrompt,
+    });
+    if (opts.mock) {
+      await writeMockResponse(opts.outputResponse, gmStartFrom);
+    } else {
+      await runCall({
+        inputPrompt: opts.outputPrompt,
+        outputResponse: opts.outputResponse,
+        apiKey: opts.apiKey,
+      });
+    }
+    await runParse({
+      inputJson: opts.outputResponse,
+      outputEvents: opts.outputEvents,
+    });
+    const forecastEvents = await readEngineEvents(opts.outputEvents, 'output-events');
+    const historyWithForecast = sortAndDedupEvents([...historyForPrompt, ...forecastEvents]);
+    const gmUntil = aggregate(historyWithForecast).latestDate ?? gmStartFrom;
+    const gmTurnFinished: EngineEvent = {
+      type: 'turn-finished',
+      actor: 'game_master',
+      from: gmStartFrom,
+      until: gmUntil,
+    };
+    const finalHistory = sortAndDedupEvents([...historyWithForecast, gmTurnFinished]);
+    await writeEventsJsonl(finalHistoryPath, finalHistory);
+    await runAggregate({
+      inputHistory: finalHistoryPath,
+      outputState: opts.outputState,
+      outputHistory: opts.outputHistory,
+    });
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+function earliestDate(events: EngineEvent[]): string {
+  const dates = events
+    .map(eventDate)
+    .filter((value): value is string => Boolean(value))
+    .sort();
+  if (!dates.length) {
+    throw new Error('turn: new events must include at least one dated event.');
+  }
+  return dates[0];
+}
+
+function eventDate(event: EngineEvent): string | null {
+  if ('date' in event && typeof event.date === 'string') return event.date;
+  if (event.type === 'turn-started') return event.from;
+  if (event.type === 'turn-finished') return event.until;
+  return null;
+}
+
+async function writeMockResponse(path: string, date: string) {
+  const commands = [
+    {
+      type: 'publish-news',
+      date,
+      icon: 'Landmark',
+      title: 'Mock forecast',
+      description: 'Deterministic mock forecast event.',
+    },
+  ];
+  await writeFile(path, JSON.stringify({ response: { text: JSON.stringify(commands) } }, null, 2), 'utf-8');
+}

--- a/packages/cli/test/turn.test.ts
+++ b/packages/cli/test/turn.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { runTurn } from '../src/commands/turn.js';
+
+describe('runTurn', () => {
+  it('runs the full turn pipeline with mock output and emits turn markers', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cli-turn-'));
+    const inputHistory = join(dir, 'history.jsonl');
+    const newEvents = join(dir, 'new-events.jsonl');
+    const outputHistory = join(dir, 'output-history.jsonl');
+    const outputState = join(dir, 'output-state.json');
+    const outputPrompt = join(dir, 'prompt.json');
+    const outputResponse = join(dir, 'response.json');
+    const outputEvents = join(dir, 'events.jsonl');
+
+    await writeFile(
+      inputHistory,
+      JSON.stringify({
+        type: 'news-published',
+        date: '2025-01-01',
+        icon: 'Landmark',
+        title: 'Seed headline',
+        description: 'Seed description',
+      }),
+      'utf-8'
+    );
+
+    await writeFile(
+      newEvents,
+      JSON.stringify({
+        type: 'news-published',
+        date: '2025-01-02',
+        icon: 'Landmark',
+        title: 'Player headline',
+        description: 'Player description',
+      }),
+      'utf-8'
+    );
+
+    await runTurn({
+      inputHistory,
+      newEvents,
+      outputHistory,
+      outputState,
+      outputPrompt,
+      outputResponse,
+      outputEvents,
+      model: 'gemini-2.5-flash',
+      systemPrompt: '',
+      mock: true,
+    });
+
+    const lines = (await readFile(outputHistory, 'utf-8')).split(/\r?\n/).filter(Boolean);
+    const events = lines.map(line => JSON.parse(line));
+    const markers = events.filter(event => event.type === 'turn-started' || event.type === 'turn-finished');
+
+    expect(markers).toHaveLength(4);
+    const markerKeys = markers.map((event: { type: string; actor: string }) => `${event.type}-${event.actor}`);
+    expect(markerKeys).toContain('turn-started-player');
+    expect(markerKeys).toContain('turn-finished-player');
+    expect(markerKeys).toContain('turn-started-game_master');
+    expect(markerKeys).toContain('turn-finished-game_master');
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -97,7 +97,12 @@ export function createEngine(config: Config): EngineApi {
 export function aggregate(history: EngineEvent[]): AggregatedState {
   const events = sortAndDedupEvents(history);
   const dateCandidates = events
-    .map(evt => ('date' in evt ? (evt as { date: string }).date : evt.type === 'turn-started' || evt.type === 'turn-finished' ? evt.from : null))
+    .map(evt => {
+      if ('date' in evt) return (evt as { date: string }).date;
+      if (evt.type === 'turn-started') return evt.from;
+      if (evt.type === 'turn-finished') return evt.until;
+      return null;
+    })
     .filter((d): d is string => !!d)
     .sort();
   const latestDate = dateCandidates.length ? dateCandidates[dateCandidates.length - 1] : null;

--- a/packages/engine/src/utils/events.ts
+++ b/packages/engine/src/utils/events.ts
@@ -259,7 +259,8 @@ function dedupKey(event: EngineEvent): string {
 
 function eventDate(event: EngineEvent): string {
   if (hasDate(event)) return event.date;
-  if (event.type === 'turn-started' || event.type === 'turn-finished') return event.from;
+  if (event.type === 'turn-started') return event.from;
+  if (event.type === 'turn-finished') return event.until;
   return '1970-01-01';
 }
 
@@ -273,4 +274,3 @@ function hasDate(
   | GameOverEvent {
   return 'date' in event && typeof (event as { date?: string }).date === 'string';
 }
-

--- a/packages/engine/src/utils/promptProjector.ts
+++ b/packages/engine/src/utils/promptProjector.ts
@@ -57,6 +57,7 @@ function buildTimeline(history: EngineEvent[]) {
 
 function extractEventDate(event: EngineEvent): string | null {
   if ('date' in event && typeof event.date === 'string') return event.date;
-  if (event.type === 'turn-started' || event.type === 'turn-finished') return event.from;
+  if (event.type === 'turn-started') return event.from;
+  if (event.type === 'turn-finished') return event.until;
   return null;
 }


### PR DESCRIPTION
Summary
- Engine: treat `turn-finished` as ending at `until` for event ordering + derived `latestDate`.
- Webapp: append `turn-started`/`turn-finished` for both `player` and `game_master` around submit/forecast; keep revert-on-error behavior coherent.
- CLI: add `turn` command composing aggregate → prepare → call/--mock → parse → aggregate; add a mock-mode integration test.

Closes #8
Closes #3
