### PR TITLE
Turn markers + CLI turn command (b)

### DIFF
--- a/packages/cli/src/commands/turn.ts
+++ b/packages/cli/src/commands/turn.ts
@@ -1,0 +1,149 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  aggregate,
+  nextDateAfter,
+  sortAndDedupEvents,
+  type EngineEvent,
+} from '@ai-forecasting/engine';
+import { readEngineEvents, writeEventsJsonl } from './eventIo.js';
+import { runAggregate } from './aggregate.js';
+import { runPrepare } from './prepare.js';
+import { runCall } from './call.js';
+import { runParse } from './parse.js';
+
+const today = () => new Date().toISOString().split('T')[0];
+
+export async function runTurn(opts: {
+  inputHistory: string;
+  newEvents: string;
+  outputState: string;
+  outputHistory: string;
+  outputPrompt: string;
+  outputResponse: string;
+  outputEvents: string;
+  materials?: string;
+  model: string;
+  systemPrompt: string;
+  apiKey?: string;
+  mock?: boolean;
+}) {
+  const history = await readEngineEvents(opts.inputHistory, 'input-history');
+  const playerEvents = await readEngineEvents(opts.newEvents, 'new-events');
+  const baseSummary = aggregate(history);
+  const playerFallbackDate = aggregate(playerEvents).latestDate ?? today();
+  const playerTurnStartDate = baseSummary.latestDate ?? playerFallbackDate;
+  const playerTurnStarted: EngineEvent = {
+    type: 'turn-started',
+    actor: 'player',
+    from: playerTurnStartDate,
+    until: playerTurnStartDate,
+  };
+  const historyAfterPlayerBase = sortAndDedupEvents([
+    ...history,
+    playerTurnStarted,
+    ...playerEvents,
+  ]);
+  const playerTurnUntil =
+    aggregate(historyAfterPlayerBase).latestDate ?? playerTurnStartDate;
+  const playerTurnFinished: EngineEvent = {
+    type: 'turn-finished',
+    actor: 'player',
+    from: playerTurnStartDate,
+    until: playerTurnUntil,
+  };
+  const playerAdditions = [
+    playerTurnStarted,
+    ...playerEvents,
+    playerTurnFinished,
+  ];
+
+  const tmpDir = await mkdtemp(join(tmpdir(), 'cli-turn-'));
+  const playerAdditionsPath = join(tmpDir, 'player-additions.jsonl');
+  const playerStatePath = join(tmpDir, 'player-state.json');
+  const playerHistoryPath = join(tmpDir, 'player-history.jsonl');
+  const gmHistoryPath = join(tmpDir, 'gm-history.jsonl');
+  const gmAdditionsPath = join(tmpDir, 'gm-additions.jsonl');
+
+  await writeEventsJsonl(playerAdditionsPath, playerAdditions);
+  await runAggregate({
+    inputHistory: opts.inputHistory,
+    newEvents: playerAdditionsPath,
+    outputState: playerStatePath,
+    outputHistory: playerHistoryPath,
+  });
+
+  const playerHistory = await readEngineEvents(playerHistoryPath, 'player-history');
+  const gmTurnStartDate = aggregate(playerHistory).latestDate ?? playerTurnUntil;
+  const gmTurnStarted: EngineEvent = {
+    type: 'turn-started',
+    actor: 'game_master',
+    from: gmTurnStartDate,
+    until: gmTurnStartDate,
+  };
+  const historyWithGmStart = sortAndDedupEvents([
+    ...playerHistory,
+    gmTurnStarted,
+  ]);
+  await writeEventsJsonl(gmHistoryPath, historyWithGmStart);
+
+  await runPrepare({
+    inputState: '',
+    inputHistory: gmHistoryPath,
+    materials: opts.materials,
+    model: opts.model,
+    systemPrompt: opts.systemPrompt,
+    outputPrompt: opts.outputPrompt,
+  });
+
+  if (opts.mock) {
+    const mockDate = nextDateAfter(historyWithGmStart);
+    const commands = [
+      {
+        type: 'publish-news',
+        date: mockDate,
+        icon: 'BrainCircuit',
+        title: 'MOCK forecast event',
+        description: 'Placeholder forecast from CLI mock mode.',
+      },
+    ];
+    await writeFile(
+      opts.outputResponse,
+      JSON.stringify({ response: { text: JSON.stringify(commands) }, chunks: [] }, null, 2),
+      'utf-8'
+    );
+  } else {
+    await runCall({
+      inputPrompt: opts.outputPrompt,
+      outputResponse: opts.outputResponse,
+      apiKey: opts.apiKey,
+    });
+  }
+
+  await runParse({
+    inputJson: opts.outputResponse,
+    outputEvents: opts.outputEvents,
+  });
+
+  const forecastEvents = await readEngineEvents(opts.outputEvents, 'output-events');
+  const historyWithForecast = sortAndDedupEvents([
+    ...historyWithGmStart,
+    ...forecastEvents,
+  ]);
+  const gmTurnUntil = aggregate(historyWithForecast).latestDate ?? gmTurnStartDate;
+  const gmTurnFinished: EngineEvent = {
+    type: 'turn-finished',
+    actor: 'game_master',
+    from: gmTurnStartDate,
+    until: gmTurnUntil,
+  };
+  await writeEventsJsonl(gmAdditionsPath, [...forecastEvents, gmTurnFinished]);
+
+  await runAggregate({
+    inputHistory: gmHistoryPath,
+    newEvents: gmAdditionsPath,
+    outputState: opts.outputState,
+    outputHistory: opts.outputHistory,
+  });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 /**
- * CLI dispatcher (fine-grained commands only for now).
- * Commands: aggregate | prepare | call | parse | download-snapshots
- * Convenience wrappers (e.g., turn) intentionally deferred until the base
- * pipeline is confirmed.
+ * CLI dispatcher.
+ * Commands: aggregate | prepare | call | parse | turn | download-snapshots
  */
 import { parseArgs } from 'node:util';
 
@@ -12,6 +10,7 @@ import { runPrepare } from './commands/prepare.js';
 import { runCall } from './commands/call.js';
 import { runParse } from './commands/parse.js';
 import { runDownloadSnapshots } from './commands/downloadSnapshots.js';
+import { runTurn } from './commands/turn.js';
 
 const argv = parseArgs({
   options: {
@@ -34,6 +33,8 @@ const argv = parseArgs({
     // parse
     'input-json': { type: 'string' },
     'output-events': { type: 'string' },
+    // turn
+    mock: { type: 'boolean' },
     // download-snapshots
     'sources': { type: 'string' },
     'output': { type: 'string' },
@@ -103,8 +104,40 @@ async function main() {
       });
       break;
     }
+    case 'turn': {
+      const inputHistory = argv.values['input-history'];
+      const newEvents = argv.values['new-events'];
+      const outputState = argv.values['output-state'];
+      const outputHistory = argv.values['output-history'];
+      const outputPrompt = argv.values['output-prompt'];
+      const outputResponse = argv.values['output-response'];
+      const outputEvents = argv.values['output-events'];
+      if (!inputHistory || !newEvents || !outputState || !outputHistory) {
+        throw new Error('turn requires --input-history, --new-events, --output-state, --output-history');
+      }
+      if (!outputPrompt || !outputResponse || !outputEvents) {
+        throw new Error('turn requires --output-prompt, --output-response, --output-events');
+      }
+      await runTurn({
+        inputHistory,
+        newEvents,
+        outputState,
+        outputHistory,
+        outputPrompt,
+        outputResponse,
+        outputEvents,
+        materials: argv.values['materials'],
+        model: argv.values['model'] || 'gemini-2.5-flash',
+        systemPrompt: argv.values['system-prompt'] || '',
+        apiKey: argv.values['api-key'] || process.env.GEMINI_API_KEY,
+        mock: argv.values['mock'] || false,
+      });
+      break;
+    }
     default:
-      throw new Error('Unknown or missing command. Use aggregate|prepare|call|parse|download-snapshots.');
+      throw new Error(
+        'Unknown or missing command. Use aggregate|prepare|call|parse|turn|download-snapshots.'
+      );
   }
 }
 

--- a/packages/cli/test/turn.test.ts
+++ b/packages/cli/test/turn.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { runTurn } from '../src/commands/turn.js';
+
+describe('runTurn', () => {
+  it('runs the full turn pipeline in mock mode and emits turn markers', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cli-turn-'));
+    const inputHistory = join(dir, 'history.jsonl');
+    const newEvents = join(dir, 'player.jsonl');
+    const outputHistory = join(dir, 'output-history.jsonl');
+    const outputState = join(dir, 'output-state.json');
+    const outputPrompt = join(dir, 'prompt.json');
+    const outputResponse = join(dir, 'response.json');
+    const outputEvents = join(dir, 'gm-events.jsonl');
+
+    const seedEvents = [
+      {
+        type: 'news-published',
+        date: '2025-01-01',
+        icon: 'Landmark',
+        title: 'Seed event',
+        description: 'Seed description',
+      },
+    ];
+    await writeFile(inputHistory, seedEvents.map(evt => JSON.stringify(evt)).join('\n'), 'utf-8');
+
+    const playerEvents = [
+      {
+        type: 'news-published',
+        date: '2025-01-02',
+        icon: 'Globe',
+        title: 'Player event',
+        description: 'Player description',
+      },
+    ];
+    await writeFile(newEvents, playerEvents.map(evt => JSON.stringify(evt)).join('\n'), 'utf-8');
+
+    await runTurn({
+      inputHistory,
+      newEvents,
+      outputHistory,
+      outputState,
+      outputPrompt,
+      outputResponse,
+      outputEvents,
+      materials: 'none',
+      model: 'gemini-2.5-flash',
+      systemPrompt: '',
+      mock: true,
+    });
+
+    const lines = (await readFile(outputHistory, 'utf-8')).split(/\r?\n/).filter(Boolean);
+    const events = lines.map(line => JSON.parse(line));
+    const started = events.filter((evt: { type?: string }) => evt.type === 'turn-started');
+    const finished = events.filter((evt: { type?: string }) => evt.type === 'turn-finished');
+
+    expect(started).toHaveLength(2);
+    expect(finished).toHaveLength(2);
+    expect(started.map((evt: { actor?: string }) => evt.actor).sort()).toEqual([
+      'game_master',
+      'player',
+    ]);
+    expect(finished.map((evt: { actor?: string }) => evt.actor).sort()).toEqual([
+      'game_master',
+      'player',
+    ]);
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -97,7 +97,15 @@ export function createEngine(config: Config): EngineApi {
 export function aggregate(history: EngineEvent[]): AggregatedState {
   const events = sortAndDedupEvents(history);
   const dateCandidates = events
-    .map(evt => ('date' in evt ? (evt as { date: string }).date : evt.type === 'turn-started' || evt.type === 'turn-finished' ? evt.from : null))
+    .map(evt =>
+      'date' in evt
+        ? (evt as { date: string }).date
+        : evt.type === 'turn-started'
+          ? evt.from
+          : evt.type === 'turn-finished'
+            ? evt.until
+            : null
+    )
     .filter((d): d is string => !!d)
     .sort();
   const latestDate = dateCandidates.length ? dateCandidates[dateCandidates.length - 1] : null;

--- a/packages/engine/src/utils/events.ts
+++ b/packages/engine/src/utils/events.ts
@@ -259,7 +259,8 @@ function dedupKey(event: EngineEvent): string {
 
 function eventDate(event: EngineEvent): string {
   if (hasDate(event)) return event.date;
-  if (event.type === 'turn-started' || event.type === 'turn-finished') return event.from;
+  if (event.type === 'turn-started') return event.from;
+  if (event.type === 'turn-finished') return event.until;
   return '1970-01-01';
 }
 
@@ -273,4 +274,3 @@ function hasDate(
   | GameOverEvent {
   return 'date' in event && typeof (event as { date?: string }).date === 'string';
 }
-

--- a/packages/engine/src/utils/promptProjector.ts
+++ b/packages/engine/src/utils/promptProjector.ts
@@ -57,6 +57,7 @@ function buildTimeline(history: EngineEvent[]) {
 
 function extractEventDate(event: EngineEvent): string | null {
   if ('date' in event && typeof event.date === 'string') return event.date;
-  if (event.type === 'turn-started' || event.type === 'turn-finished') return event.from;
+  if (event.type === 'turn-started') return event.from;
+  if (event.type === 'turn-finished') return event.until;
   return null;
 }


### PR DESCRIPTION
Summary
- Engine: treat `turn-finished` as ending at `until` for event ordering + derived `latestDate`.
- Webapp: append `turn-started`/`turn-finished` for both `player` and `game_master` around submit/forecast; keep revert-on-error behavior coherent.
- CLI: add `turn` command composing aggregate → prepare → call/--mock → parse → aggregate; add a mock-mode integration test.

Closes #8
Closes #3
