### PR TITLE
Turn markers + CLI turn command (c)

### DIFF
--- a/packages/cli/src/commands/turn.ts
+++ b/packages/cli/src/commands/turn.ts
@@ -1,0 +1,156 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  aggregate,
+  nextDateAfter,
+  sortAndDedupEvents,
+  type Command,
+  type EngineEvent,
+} from '@ai-forecasting/engine';
+import { readEngineEvents, writeEventsJsonl } from './eventIo.js';
+import { runAggregate } from './aggregate.js';
+import { runPrepare } from './prepare.js';
+import { runCall } from './call.js';
+import { runParse } from './parse.js';
+
+export async function runTurn(opts: {
+  inputHistory?: string;
+  newEvents: string;
+  outputState: string;
+  outputHistory: string;
+  outputPrompt: string;
+  outputResponse: string;
+  outputEvents: string;
+  materials?: string;
+  model: string;
+  systemPrompt: string;
+  apiKey?: string;
+  mock?: boolean;
+}) {
+  const history = opts.inputHistory ? await readEngineEvents(opts.inputHistory, 'input-history') : [];
+  const playerEvents = await readEngineEvents(opts.newEvents, 'new-events');
+  if (!playerEvents.length) {
+    throw new Error('turn requires --new-events with at least one event.');
+  }
+
+  const playerTurnFrom = pickTurnStartDate(playerEvents);
+  const playerTurnStart: EngineEvent = {
+    type: 'turn-started',
+    actor: 'player',
+    from: playerTurnFrom,
+    until: playerTurnFrom,
+  };
+  const historyAfterPlayerEvent = sortAndDedupEvents([...history, playerTurnStart, ...playerEvents]);
+  const playerTurnUntil = aggregate(historyAfterPlayerEvent).latestDate ?? playerTurnFrom;
+  const playerTurnFinished: EngineEvent = {
+    type: 'turn-finished',
+    actor: 'player',
+    from: playerTurnFrom,
+    until: playerTurnUntil,
+  };
+  const gmTurnStart: EngineEvent = {
+    type: 'turn-started',
+    actor: 'game_master',
+    from: playerTurnUntil,
+    until: playerTurnUntil,
+  };
+
+  const tempDir = await mkdtemp(join(tmpdir(), 'cli-turn-'));
+  const preForecastEventsPath = join(tempDir, 'turn-pre-forecast.jsonl');
+  const historyBeforeForecastPath = join(tempDir, 'history-before-forecast.jsonl');
+  const stateBeforeForecastPath = join(tempDir, 'state-before-forecast.json');
+  const postForecastEventsPath = join(tempDir, 'turn-post-forecast.jsonl');
+
+  await writeEventsJsonl(preForecastEventsPath, [
+    playerTurnStart,
+    ...playerEvents,
+    playerTurnFinished,
+    gmTurnStart,
+  ]);
+
+  await runAggregate({
+    inputHistory: opts.inputHistory,
+    newEvents: preForecastEventsPath,
+    outputState: stateBeforeForecastPath,
+    outputHistory: historyBeforeForecastPath,
+  });
+
+  await runPrepare({
+    inputState: stateBeforeForecastPath,
+    inputHistory: historyBeforeForecastPath,
+    materials: opts.materials,
+    model: opts.model,
+    systemPrompt: opts.systemPrompt,
+    outputPrompt: opts.outputPrompt,
+  });
+
+  if (opts.mock) {
+    const mockDate = nextDateAfter(
+      sortAndDedupEvents([...historyAfterPlayerEvent, playerTurnFinished, gmTurnStart])
+    );
+    await writeMockResponse(opts.outputResponse, mockDate);
+  } else {
+    await runCall({
+      inputPrompt: opts.outputPrompt,
+      outputResponse: opts.outputResponse,
+      apiKey: opts.apiKey,
+    });
+  }
+
+  await runParse({
+    inputJson: opts.outputResponse,
+    outputEvents: opts.outputEvents,
+  });
+
+  const historyForForecast = await readEngineEvents(historyBeforeForecastPath, 'history-before-forecast');
+  const forecastEvents = await readEngineEvents(opts.outputEvents, 'output-events');
+  const historyWithForecast = sortAndDedupEvents([...historyForForecast, ...forecastEvents]);
+  const gmTurnUntil = aggregate(historyWithForecast).latestDate ?? gmTurnStart.from;
+  const gmTurnFinished: EngineEvent = {
+    type: 'turn-finished',
+    actor: 'game_master',
+    from: gmTurnStart.from,
+    until: gmTurnUntil,
+  };
+
+  await writeEventsJsonl(postForecastEventsPath, [...forecastEvents, gmTurnFinished]);
+
+  await runAggregate({
+    inputHistory: historyBeforeForecastPath,
+    newEvents: postForecastEventsPath,
+    outputState: opts.outputState,
+    outputHistory: opts.outputHistory,
+  });
+}
+
+function pickTurnStartDate(events: EngineEvent[]): string {
+  const dates = events
+    .map(eventDate)
+    .filter((value): value is string => typeof value === 'string')
+    .sort();
+  if (!dates.length) {
+    throw new Error('turn: unable to infer a start date from --new-events.');
+  }
+  return dates[0];
+}
+
+function eventDate(event: EngineEvent): string | null {
+  if ('date' in event && typeof event.date === 'string') return event.date;
+  if (event.type === 'turn-started') return event.from;
+  if (event.type === 'turn-finished') return event.until;
+  return null;
+}
+
+async function writeMockResponse(path: string, date: string) {
+  const commands: Command[] = [
+    {
+      type: 'publish-news',
+      date,
+      icon: 'Landmark',
+      title: 'Mock forecast',
+      description: 'Mock forecast description.',
+    },
+  ];
+  await writeFile(path, JSON.stringify(commands, null, 2), 'utf-8');
+}

--- a/packages/cli/test/turn.test.ts
+++ b/packages/cli/test/turn.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { runTurn } from '../src/commands/turn.js';
+
+describe('runTurn', () => {
+  it('runs a full turn and emits player + GM markers in output history', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'cli-turn-'));
+    const newEvents = join(dir, 'new-events.jsonl');
+    const outputPrompt = join(dir, 'prompt.json');
+    const outputResponse = join(dir, 'response.json');
+    const outputEvents = join(dir, 'events.jsonl');
+    const outputHistory = join(dir, 'history.jsonl');
+    const outputState = join(dir, 'state.json');
+
+    const playerEvent = {
+      type: 'news-published',
+      date: '2025-01-02',
+      icon: 'Landmark',
+      title: 'Player event',
+      description: 'Player action.',
+    };
+    await writeFile(newEvents, `${JSON.stringify(playerEvent)}\n`, 'utf-8');
+
+    await runTurn({
+      newEvents,
+      outputPrompt,
+      outputResponse,
+      outputEvents,
+      outputHistory,
+      outputState,
+      materials: 'none',
+      model: 'gemini-2.5-flash',
+      systemPrompt: '',
+      mock: true,
+    });
+
+    const historyLines = (await readFile(outputHistory, 'utf-8')).split(/\r?\n/).filter(Boolean);
+    const history = historyLines.map(line => JSON.parse(line));
+
+    const markerTypes = history
+      .filter((evt: { type: string }) => evt.type === 'turn-started' || evt.type === 'turn-finished')
+      .map((evt: { actor: string }) => evt.actor);
+
+    expect(markerTypes).toContain('player');
+    expect(markerTypes).toContain('game_master');
+    expect(markerTypes.filter(actor => actor === 'player')).toHaveLength(2);
+    expect(markerTypes.filter(actor => actor === 'game_master')).toHaveLength(2);
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -97,7 +97,15 @@ export function createEngine(config: Config): EngineApi {
 export function aggregate(history: EngineEvent[]): AggregatedState {
   const events = sortAndDedupEvents(history);
   const dateCandidates = events
-    .map(evt => ('date' in evt ? (evt as { date: string }).date : evt.type === 'turn-started' || evt.type === 'turn-finished' ? evt.from : null))
+    .map(evt =>
+      'date' in evt
+        ? (evt as { date: string }).date
+        : evt.type === 'turn-started'
+          ? evt.from
+          : evt.type === 'turn-finished'
+            ? evt.until
+            : null
+    )
     .filter((d): d is string => !!d)
     .sort();
   const latestDate = dateCandidates.length ? dateCandidates[dateCandidates.length - 1] : null;

--- a/packages/engine/src/utils/events.ts
+++ b/packages/engine/src/utils/events.ts
@@ -259,7 +259,8 @@ function dedupKey(event: EngineEvent): string {
 
 function eventDate(event: EngineEvent): string {
   if (hasDate(event)) return event.date;
-  if (event.type === 'turn-started' || event.type === 'turn-finished') return event.from;
+  if (event.type === 'turn-started') return event.from;
+  if (event.type === 'turn-finished') return event.until;
   return '1970-01-01';
 }
 
@@ -273,4 +274,3 @@ function hasDate(
   | GameOverEvent {
   return 'date' in event && typeof (event as { date?: string }).date === 'string';
 }
-

--- a/packages/engine/src/utils/promptProjector.ts
+++ b/packages/engine/src/utils/promptProjector.ts
@@ -57,6 +57,7 @@ function buildTimeline(history: EngineEvent[]) {
 
 function extractEventDate(event: EngineEvent): string | null {
   if ('date' in event && typeof event.date === 'string') return event.date;
-  if (event.type === 'turn-started' || event.type === 'turn-finished') return event.from;
+  if (event.type === 'turn-started') return event.from;
+  if (event.type === 'turn-finished') return event.until;
   return null;
 }


### PR DESCRIPTION
Summary
- Engine: treat `turn-finished` as ending at `until` for event ordering + derived `latestDate`.
- Webapp: append `turn-started`/`turn-finished` for both `player` and `game_master` around submit/forecast; keep revert-on-error behavior coherent.
- CLI: add `turn` command composing aggregate → prepare → call/--mock → parse → aggregate; add a mock-mode integration test.

Closes #8
Closes #3
